### PR TITLE
feat(examples/next-hybrid): Added instructions for enabling prompt api and link to guide

### DIFF
--- a/examples/next-hybrid/app/(core)/page.tsx
+++ b/examples/next-hybrid/app/(core)/page.tsx
@@ -45,6 +45,7 @@ import { Kbd, KbdKey } from "@/components/ui/kbd";
 import { ModelSelector } from "@/components/model-selector";
 import { SiGithub } from "@icons-pack/react-simple-icons";
 import Link from "next/link";
+import { BrowserSupportInstructions } from "@/components/browser-support-instructions";
 
 const doesBrowserSupportModel = doesBrowserSupportBuiltInAI();
 
@@ -165,9 +166,9 @@ export default function Chat() {
         </div>
       </header>
       {messages.length === 0 && (
-        <div className="flex h-full flex-col items-center justify-center text-center">
+        <>
           {browserSupportsModel ? (
-            <>
+            <div className="flex h-full flex-col items-center justify-center text-center">
               <p className="text-xs">@built-in-ai/core demo</p>
               <h1 className="text-lg font-medium">
                 Using your browser's built-in AI model
@@ -175,16 +176,11 @@ export default function Chat() {
               <p className="text-sm max-w-xs">
                 Your browser supports built-in AI models
               </p>
-            </>
+            </div>
           ) : (
-            <>
-              <h1 className="text-lg font-medium">Using server-side model</h1>
-              <p className="text-sm max-w-xs">
-                Your device doesn&apos;t support built-in AI models
-              </p>
-            </>
+            <BrowserSupportInstructions />
           )}
-        </div>
+        </>
       )}
       <Conversation className="flex-1">
         <ConversationContent>

--- a/examples/next-hybrid/components/browser-support-instructions.tsx
+++ b/examples/next-hybrid/components/browser-support-instructions.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { ExternalLinkIcon } from "lucide-react";
+import Link from "next/link";
+
+export function BrowserSupportInstructions() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center text-center max-w-lg mx-auto">
+      <h1 className="text-lg font-medium mb-4">Using server-side model</h1>
+      <p className="text-sm text-muted-foreground mb-6">
+        Your device doesn&apos;t support built-in AI models
+      </p>
+
+      <div className="bg-accent/50 border rounded-lg p-4 text-left mb-4 w-full">
+        <div className="flex items-center gap-2 mb-3">
+          <div className="w-2 h-2 bg-yellow-500 rounded-full" />
+          <span className="text-sm font-medium">Important</span>
+        </div>
+        <p className="text-xs text-muted-foreground mb-4">
+          The Prompt API is currently experimental and might change as it
+          matures. The guide below to enable the Prompt API might also change in
+          the future.
+        </p>
+
+        <div className="space-y-3">
+          <div>
+            <h3 className="text-sm font-medium mb-2">You need:</h3>
+            <ul className="text-xs text-muted-foreground space-y-1 ml-4">
+              <li>• Chrome (v. 128 or higher)</li>
+              <li>• Edge Dev/Canary (v. 138.0.3309.2 or higher)</li>
+            </ul>
+          </div>
+
+          <div>
+            <h3 className="text-sm font-medium mb-2">
+              Enable these experimental flags:
+            </h3>
+
+            <div className="mb-3">
+              <p className="text-xs font-medium text-foreground mb-1">
+                If you&apos;re using Chrome:
+              </p>
+              <ul className="text-xs text-muted-foreground space-y-1 ml-4">
+                <li>
+                  1. Go to{" "}
+                  <code className="bg-muted px-1 py-0.5 rounded text-xs">
+                    chrome://flags/
+                  </code>
+                </li>
+                <li>
+                  2. Search for &apos;Prompt API for Gemini Nano with Multimodal
+                  Input&apos;
+                </li>
+                <li>3. Set it to Enabled</li>
+                <li>
+                  4. Go to{" "}
+                  <code className="bg-muted px-1 py-0.5 rounded text-xs">
+                    chrome://components
+                  </code>
+                </li>
+                <li>
+                  5. Click Check for Update on Optimization Guide On Device
+                  Model
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <p className="text-xs font-medium text-foreground mb-1">
+                If you&apos;re using Edge:
+              </p>
+              <ul className="text-xs text-muted-foreground space-y-1 ml-4">
+                <li>
+                  1. Go to{" "}
+                  <code className="bg-muted px-1 py-0.5 rounded text-xs">
+                    edge://flags/#prompt-api-for-phi-mini
+                  </code>
+                </li>
+                <li>2. Set it to Enabled</li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="pt-2 border-t">
+            <Link
+              href="https://developer.chrome.com/docs/ai/prompt-api"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors"
+            >
+              For more information, check out this guide
+              <ExternalLinkIcon className="w-3 h-3" />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14171,7 +14171,7 @@
     },
     "packages/built-in-ai": {
       "name": "@built-in-ai/core",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache License",
       "dependencies": {
         "@mediapipe/tasks-text": "^0.10.22-rc.20250304"
@@ -14771,7 +14771,7 @@
     },
     "packages/transformers-js": {
       "name": "@built-in-ai/transformers-js",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.7.6"


### PR DESCRIPTION
Hello,

I added a small component that shows the directions for enabling the Prompt API from built-in-ai/core README.md

<img width="1509" height="777" alt="Screenshot 2025-11-17 at 12 06 59 PM" src="https://github.com/user-attachments/assets/a7c75023-0e5c-47f0-a1ec-464c8e799525" />

Thanks for the awesome project.
Let me know if I need to make any additional changes.