### PR TITLE
fix: correct ESM export paths to use .mjs extension

### DIFF
--- a/.changeset/plain-cups-slide.md
+++ b/.changeset/plain-cups-slide.md
@@ -1,0 +1,7 @@
+---
+"@browser-ai/transformers-js": patch
+"@browser-ai/web-llm": patch
+"@browser-ai/core": patch
+---
+
+fix: correct ESM export paths to use .mjs extension

--- a/packages/vercel/core/package.json
+++ b/packages/vercel/core/package.json
@@ -16,7 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
   },

--- a/packages/vercel/transformers-js/package.json
+++ b/packages/vercel/transformers-js/package.json
@@ -16,7 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
   },

--- a/packages/vercel/web-llm/package.json
+++ b/packages/vercel/web-llm/package.json
@@ -17,7 +17,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
   },


### PR DESCRIPTION
## Summary
Fixes ESM imports failing in modern bundlers (Vite, esbuild, etc.) by pointing the `import` condition to `.mjs` files.

## Problem
The `exports` field in package.json pointed to `.js` for both ESM and CJS:
```json
"import": "./dist/index.js",
"require": "./dist/index.js"
```
But tsup generates .mjs for ESM builds, causing errors like:


`The requested module does not provide an export named 'browserAI'`