### PR TITLE
fix(transformers-js): read num_mel_bins from model config during warmup

### DIFF
--- a/.changeset/fix-warmup-mel-bins.md
+++ b/.changeset/fix-warmup-mel-bins.md
@@ -1,0 +1,5 @@
+---
+"@browser-ai/transformers-js": patch
+---
+
+Read num_mel_bins from model config during warmup instead of hardcoding 80. Fixes transcription failures with Whisper large-v3 models (128 mel bins).

--- a/packages/vercel/transformers-js/src/transcription/transformers-js-transcription-model.ts
+++ b/packages/vercel/transformers-js/src/transcription/transformers-js-transcription-model.ts
@@ -154,8 +154,9 @@ export class TransformersJSTranscriptionModel implements TranscriptionModelV3 {
       // Warm up the model (skip in server environment to reduce initialization time)
       if (isBrowserEnvironment()) {
         try {
+          const numMelBins = (model.config as any).num_mel_bins ?? 80;
           await model.generate({
-            inputs: full([1, 80, 3000], 0.0),
+            inputs: full([1, numMelBins, 3000], 0.0),
           });
         } catch (error) {
           // Ignore warmup errors

--- a/packages/vercel/transformers-js/src/transcription/transformers-js-transcription-worker-handler.ts
+++ b/packages/vercel/transformers-js/src/transcription/transformers-js-transcription-worker-handler.ts
@@ -237,8 +237,9 @@ export class TransformersJSTranscriptionWorkerHandler {
 
       // Run model with dummy input to compile shaders
       try {
+        const numMelBins = (model.config as any).num_mel_bins ?? 80;
         await (model as any).generate({
-          inputs: full([1, 80, 3000], 0.0),
+          inputs: full([1, numMelBins, 3000], 0.0),
           max_new_tokens: 1,
         });
       } catch (error) {


### PR DESCRIPTION
## Summary

  - Warmup creates a dummy tensor to compile ONNX shaders. The mel bin dimension was hardcoded to `80`, which is correct for Whisper v1/v2 but wrong for ex. [Whisper-v3](https://huggingface.co/openai/whisper-large-v3) that uses `128` mel bins. 
  - This lead to silently corrupting the ONNX session. The warmup error is caught and swallowed, but every subsequent transcription fails with a dimension mismatch.
  - Now reads `num_mel_bins` from the model's config at runtime, falling back to `80` for models that don't specify it.

  ## Changes
  2 files, same one line fix in each:

  ```ts
  const numMelBins = (model.config as any).num_mel_bins ?? 80;