### PR TITLE
fix(transformers-js): guard transcription warmup when model config is missing

### DIFF
--- a/packages/vercel/transformers-js/src/transcription/transformers-js-transcription-model.ts
+++ b/packages/vercel/transformers-js/src/transcription/transformers-js-transcription-model.ts
@@ -154,7 +154,7 @@ export class TransformersJSTranscriptionModel implements TranscriptionModelV3 {
       // Warm up the model (skip in server environment to reduce initialization time)
       if (isBrowserEnvironment()) {
         try {
-          const numMelBins = (model.config as any).num_mel_bins ?? 80;
+          const numMelBins = (model.config as any)?.num_mel_bins ?? 80;
           await model.generate({
             inputs: full([1, numMelBins, 3000], 0.0),
           });


### PR DESCRIPTION
Safely read `num_mel_bins` via optional chaining (`model.config?.num_mel_bins ?? 80`). This prevents a `TypeError` and noisy stderr logs in the unit tests