### PR TITLE
feat(@browser-ai/core): rename input usage

### DIFF
--- a/.changeset/common-sloths-leave.md
+++ b/.changeset/common-sloths-leave.md
@@ -1,0 +1,5 @@
+---
+"@browser-ai/core": patch
+---
+
+renamed input usage

--- a/docs/content/docs/ai-sdk-v6/core/api-reference.mdx
+++ b/docs/content/docs/ai-sdk-v6/core/api-reference.mdx
@@ -14,7 +14,7 @@ Creates a browser AI model instance for chat.
 - `settings` (optional): Configuration options
   - `temperature?: number` - Controls randomness (0-1)
   - `topK?: number` - Limits vocabulary selection
-  - `onQuotaOverflow?: (event: Event) => void` - Callback for when model quota is exceeded
+  - `onContextOverflow?: (event: Event) => void` - Callback for when the model context window is exceeded
 
 **Returns:** `BrowserAIChatLanguageModel`
 
@@ -70,15 +70,15 @@ Creates a language model session with optional download progress monitoring.
 
 **Returns:** `Promise<BrowserAIChatLanguageModel>` - The configured language model instance
 
-### `BrowserAIChatLanguageModel.getInputUsage()`
+### `BrowserAIChatLanguageModel.getContextUsage()`
 
-Gets the current input usage of the current session. If the session is not available returns undefined.
+Gets the current context usage (tokens consumed) of the current session. If the session is not available returns undefined.
 
 **Returns:** `number | undefined`
 
-### `BrowserAIChatLanguageModel.getInputQuota()`
+### `BrowserAIChatLanguageModel.getContextWindow()`
 
-Gets the current input quota of the current session. If the session is not available returns undefined.
+Gets the context window size (token limit) of the current session. If the session is not available returns undefined.
 
 **Returns:** `number | undefined`
 

--- a/examples/next-hybrid/app/(core)/page.tsx
+++ b/examples/next-hybrid/app/(core)/page.tsx
@@ -87,14 +87,18 @@ export default function Chat() {
   const [files, setFiles] = useState<FileList | undefined>(undefined);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [quotaOverflow, setQuotaOverflow] = useState(false);
-  const [inputUsage, setInputUsage] = useState<number | undefined>(undefined);
-  const [inputQuota, setInputQuota] = useState<number | undefined>(undefined);
+  const [contextUsage, setContextUsage] = useState<number | undefined>(
+    undefined,
+  );
+  const [contextWindow, setContextWindow] = useState<number | undefined>(
+    undefined,
+  );
 
   const clientTransport = useMemo(
     () =>
       doesBrowserSupportModel
         ? new ClientSideChatTransport({
-            onQuotaOverflow: () => setQuotaOverflow(true),
+            onContextOverflow: () => setQuotaOverflow(true),
           })
         : null,
     [],
@@ -146,8 +150,8 @@ export default function Chat() {
 
   const syncInputContext = useCallback(() => {
     if (!clientTransport) return;
-    setInputUsage(clientTransport.getInputUsage());
-    setInputQuota(clientTransport.getInputQuota());
+    setContextUsage(clientTransport.getContextUsage());
+    setContextWindow(clientTransport.getContextWindow());
   }, [clientTransport]);
 
   useEffect(() => {
@@ -581,8 +585,11 @@ export default function Chat() {
               </PromptInputButton>
             </PromptInputTools>
             <div className="flex items-center gap-2">
-              {inputQuota !== undefined && inputQuota > 0 && (
-                <Context usedTokens={inputUsage ?? 0} maxTokens={inputQuota}>
+              {contextWindow !== undefined && contextWindow > 0 && (
+                <Context
+                  usedTokens={contextUsage ?? 0}
+                  maxTokens={contextWindow}
+                >
                   <ContextTrigger className="h-8 px-2.5" />
                   <ContextContent align="end">
                     <ContextContentHeader />

--- a/packages/vercel/core/src/chat/browser-ai-language-model.ts
+++ b/packages/vercel/core/src/chat/browser-ai-language-model.ts
@@ -36,7 +36,14 @@ export interface BrowserAIChatSettings extends LanguageModelCreateOptions {
   }>;
 
   /**
-   * Callback invoked when the model quota is exceeded.
+   * Callback invoked when the model context window is exceeded.
+   * Replaces the deprecated `onQuotaOverflow`.
+   * @see [Prompt API Context Overflow](https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#tokenization-context-window-length-limits-and-overflow)
+   */
+  onContextOverflow?: (event: Event) => void;
+
+  /**
+   * @deprecated Use `onContextOverflow` instead.
    * @see [Prompt API Quota Overflow](https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#tokenization-context-window-length-limits-and-overflow)
    * @param event
    */
@@ -297,19 +304,33 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
   }
 
   /**
-   * Gets the input usage for the current session, if available
-   * @returns The input usage or undefined if not available
+   * Gets the current context usage (tokens consumed) for the current session, if available
+   * @returns The context usage or undefined if not available
    */
-  public getInputUsage(): number | undefined {
-    return this.sessionManager.getInputUsage();
+  public getContextUsage(): number | undefined {
+    return this.sessionManager.getContextUsage();
   }
 
   /**
-   * Gets the input quota for the current session, if available
-   * @returns The input quota or undefined if not available
+   * Gets the context window size (token limit) for the current session, if available
+   * @returns The context window size or undefined if not available
+   */
+  public getContextWindow(): number | undefined {
+    return this.sessionManager.getContextWindow();
+  }
+
+  /**
+   * @deprecated Use {@link getContextUsage} instead.
+   */
+  public getInputUsage(): number | undefined {
+    return this.getContextUsage();
+  }
+
+  /**
+   * @deprecated Use {@link getContextWindow} instead.
    */
   public getInputQuota(): number | undefined {
-    return this.sessionManager.getInputQuota();
+    return this.getContextWindow();
   }
 
   /**
@@ -436,7 +457,8 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
             finishReason,
             usage: {
               inputTokens: {
-                total: session.inputUsage,
+                total:
+                  (session as LanguageModel).contextUsage ?? session.inputUsage,
                 noCache: undefined,
                 cacheRead: undefined,
                 cacheWrite: undefined,

--- a/packages/vercel/core/src/dom-chromium-ai-augmentation.d.ts
+++ b/packages/vercel/core/src/dom-chromium-ai-augmentation.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Type augmentation for the Prompt API's renamed properties.
+ *
+ * The @types/dom-chromium-ai package still uses the old property names
+ * (inputUsage, inputQuota, measureInputUsage, onquotaoverflow). The spec
+ * has renamed these and removed them from non-extension web contexts:
+ *
+ *   inputUsage         → contextUsage
+ *   inputQuota         → contextWindow
+ *   measureInputUsage  → measureContextUsage
+ *   onquotaoverflow    → oncontextoverflow
+ *
+ * This file merges the new names into the existing LanguageModel global interface
+ * so TypeScript can resolve them. Once @types/dom-chromium-ai ships these names
+ * natively this file can be deleted.
+ */
+
+declare global {
+  interface LanguageModel {
+    /** @see https://github.com/webmachinelearning/prompt-api */
+    readonly contextUsage: number;
+    /** @see https://github.com/webmachinelearning/prompt-api */
+    readonly contextWindow: number;
+    /** @see https://github.com/webmachinelearning/prompt-api */
+    measureContextUsage(
+      input: LanguageModelPrompt,
+      options?: LanguageModelPromptOptions,
+    ): Promise<number>;
+    /** @see https://github.com/webmachinelearning/prompt-api */
+    oncontextoverflow: ((this: LanguageModel, ev: Event) => unknown) | null;
+  }
+}
+
+export {};


### PR DESCRIPTION
This PR addresses #150 

Because `@types/dom-chromium-ai` has not yet shipped the new names, yet, dom-chromium-ai-augmentation.d.ts was created to fill this gap.

**`src/dom-chromium-ai-augmentation.d.ts`** *(new)*
Merges the four new members into the existing global `LanguageModel` interface via TypeScript declaration merging. No types are duplicated or overridden — the new names simply sit alongside the old ones that `@types/dom-chromium-ai` already provides. Once the upstream package ships the new names, this file can be deleted with no other changes required.

## Runtime changes

- Session event registration now detects support at runtime: registers `contextoverflow` when `"oncontextoverflow" in session`, falls back to `quotaoverflow` for older Chrome builds.
- `getContextUsage()` and `getContextWindow()` read `contextUsage`/`contextWindow` with `?? inputUsage`/`?? inputQuota` as a fallback, so both old and new Chrome builds work correctly.
- `onContextOverflow` is the new option name; `onQuotaOverflow` is retained as a `@deprecated` alias that resolves through the same code path.

## Public API changes (`@browser-ai/core`)

- `getContextUsage()` / `getContextWindow()` — new methods (replace `getInputUsage()` / `getInputQuota()`)
- `onContextOverflow` — new setting (replaces `onQuotaOverflow`)
- Old names kept as `@deprecated` aliases for backward compatibility

## Other files updated

- `examples/next-hybrid` — updated to use new method and option names
- `docs/content/docs/ai-sdk-v6/core/api-reference.mdx` — updated API reference
- `test/session-manager.test.ts` — 33 tests, all passing (3 new tests cover fallback paths and deprecated alias behaviour)
