### PR TITLE
fix(@browser-ai/core): set LanguageModelCreateCoreOptions when calling availability

### DIFF
--- a/.changeset/small-spies-check.md
+++ b/.changeset/small-spies-check.md
@@ -1,0 +1,5 @@
+---
+"@browser-ai/core": patch
+---
+
+Set LanguageModelCreateCoreOptions when calling availability

--- a/examples/next-hybrid/app/(core)/util/client-side-chat-transport.ts
+++ b/examples/next-hybrid/app/(core)/util/client-side-chat-transport.ts
@@ -106,6 +106,7 @@ export class ClientSideChatTransport implements ChatTransport<BrowserAIUIMessage
       options.onContextOverflow ?? options.onQuotaOverflow;
     this.model = browserAI("text", {
       expectedInputs: [{ type: "text" }, { type: "image" }, { type: "audio" }],
+      expectedOutputs: [{ type: "text", languages: ["en"] }],
       onContextOverflow: this.onContextOverflow,
     });
   }

--- a/packages/vercel/core/src/chat/session-manager.ts
+++ b/packages/vercel/core/src/chat/session-manager.ts
@@ -104,7 +104,9 @@ export class SessionManager {
     }
 
     // Check availability before attempting to create
-    const availability = await LanguageModel.availability();
+    const availability = await LanguageModel.availability(
+      this.prepareAvailabilityOptions(options),
+    );
     if (availability === "unavailable") {
       throw new LoadSettingError({
         message: "Built-in model not available in this browser",
@@ -113,7 +115,6 @@ export class SessionManager {
 
     // Prepare session options
     const sessionOptions = this.prepareSessionOptions(options);
-
     // Create the session
     this.session = await LanguageModel.create(sessionOptions);
 
@@ -186,11 +187,13 @@ export class SessionManager {
    * }
    * ```
    */
-  async checkAvailability(): Promise<Availability> {
+  async checkAvailability(
+    options?: SessionCreateOptions,
+  ): Promise<Availability> {
     if (typeof LanguageModel === "undefined") {
       return "unavailable";
     }
-    return LanguageModel.availability();
+    return LanguageModel.availability(this.prepareAvailabilityOptions(options));
   }
 
   /**
@@ -249,6 +252,42 @@ export class SessionManager {
    */
   getInputUsage(): number | undefined {
     return this.getContextUsage();
+  }
+
+  /**
+   * Prepares merged availability options from base config and request options
+   *
+   * @param options - Optional request-specific options
+   * @returns Merged and sanitized core options ready for LanguageModel.availability()
+   * @private
+   */
+  private prepareAvailabilityOptions(
+    options?: SessionCreateOptions,
+  ): LanguageModelCreateCoreOptions {
+    const mergedOptions = { ...this.baseOptions, ...options };
+    const availabilityOptions: LanguageModelCreateCoreOptions = {};
+
+    if (mergedOptions.topK !== undefined) {
+      availabilityOptions.topK = mergedOptions.topK;
+    }
+
+    if (mergedOptions.temperature !== undefined) {
+      availabilityOptions.temperature = mergedOptions.temperature;
+    }
+
+    if (mergedOptions.expectedInputs !== undefined) {
+      availabilityOptions.expectedInputs = mergedOptions.expectedInputs;
+    }
+
+    if (mergedOptions.expectedOutputs !== undefined) {
+      availabilityOptions.expectedOutputs = mergedOptions.expectedOutputs;
+    }
+
+    if (mergedOptions.tools !== undefined) {
+      availabilityOptions.tools = mergedOptions.tools;
+    }
+
+    return availabilityOptions;
   }
 
   /**

--- a/packages/vercel/core/test/session-manager.test.ts
+++ b/packages/vercel/core/test/session-manager.test.ts
@@ -57,6 +57,25 @@ describe("SessionManager", () => {
 
       expect(availability).toBe("available");
       expect(mockAvailability).toHaveBeenCalledTimes(1);
+      expect(mockAvailability).toHaveBeenCalledWith({});
+    });
+
+    it("should pass expectedOutputs to LanguageModel.availability", async () => {
+      const mockAvailability = vi.fn().mockResolvedValue("available");
+      vi.stubGlobal("LanguageModel", {
+        availability: mockAvailability,
+        create: vi.fn(),
+      });
+
+      const manager = new SessionManager({
+        expectedOutputs: [{ type: "text", languages: ["en"] }],
+      });
+
+      await manager.checkAvailability();
+
+      expect(mockAvailability).toHaveBeenCalledWith({
+        expectedOutputs: [{ type: "text", languages: ["en"] }],
+      });
     });
 
     it("should return downloadable when model needs download", async () => {
@@ -113,6 +132,32 @@ describe("SessionManager", () => {
 
       expect(session).toBe(mockSession);
       expect(mockCreate).toHaveBeenCalledWith({ temperature: 0.7 });
+    });
+
+    it("should pass merged core options to availability before create", async () => {
+      const mockSession = {
+        prompt: vi.fn(),
+        destroy: vi.fn(),
+        addEventListener: vi.fn(),
+      };
+      const mockAvailability = vi.fn().mockResolvedValue("available");
+
+      vi.stubGlobal("LanguageModel", {
+        availability: mockAvailability,
+        create: vi.fn().mockResolvedValue(mockSession),
+      });
+
+      const manager = new SessionManager({
+        temperature: 0.5,
+        expectedOutputs: [{ type: "text", languages: ["en"] }],
+      });
+
+      await manager.getSession({ temperature: 0.8 });
+
+      expect(mockAvailability).toHaveBeenCalledWith({
+        temperature: 0.8,
+        expectedOutputs: [{ type: "text", languages: ["en"] }],
+      });
     });
 
     it("should reuse existing session", async () => {


### PR DESCRIPTION
This PR fixes the warning below that appears in the example app.

```
No output language was specified in a LanguageModel API request. An output language should be specified to ensure optimal output quality and properly attest to output safety. Please specify a supported output language code: [en, es, ja]
```

The issue was when we were calling LanguageModel.availability() we were not passing in the LanguageModelCreateCoreOptions. So even if the browser-ai/core model was created with expectedOutputs the warning is still generated. This PR fixes that.

See [here](https://developer.chrome.com/docs/ai/prompt-api#request-based_output)