### PR TITLE
fix(@browser-ai/core): omit initialPrompts from BrowserAIChatSettings

### DIFF
--- a/.changeset/shiny-wasps-shave.md
+++ b/.changeset/shiny-wasps-shave.md
@@ -1,0 +1,5 @@
+---
+"@browser-ai/core": patch
+---
+
+omit initialPrompts from BrowserAIChatSettings

--- a/packages/vercel/core/src/chat/browser-ai-language-model.ts
+++ b/packages/vercel/core/src/chat/browser-ai-language-model.ts
@@ -26,7 +26,10 @@ import { SessionManager } from "./session-manager";
 
 export type BrowserAIChatModelId = "text";
 
-export interface BrowserAIChatSettings extends LanguageModelCreateOptions {
+export interface BrowserAIChatSettings extends Omit<
+  LanguageModelCreateOptions,
+  "initialPrompts"
+> {
   /**
    * Expected input types for the session, for multimodal inputs.
    */


### PR DESCRIPTION
Based on the comment by @jakobhoeg [here](https://github.com/jakobhoeg/browser-ai/pull/174#pullrequestreview-3980736918), this PR removes the initialPrompts property from BrowserAIChatSettings. The AI SDK equivalent (system, prompt) should be used instead, so exposing this Prompt API-native property is unnecessary and potentially confusing.