### PR TITLE
fix(@browser-ai/core): forward doGenerate abort signals to browser AI

### DIFF
--- a/.changeset/cuddly-apples-remain.md
+++ b/.changeset/cuddly-apples-remain.md
@@ -1,0 +1,5 @@
+---
+"@browser-ai/core": patch
+---
+
+forward doGenerate abort signals to browser AI

--- a/packages/vercel/core/src/chat/browser-ai-language-model.ts
+++ b/packages/vercel/core/src/chat/browser-ai-language-model.ts
@@ -224,12 +224,17 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
     );
 
     const session = await this.getSession(
-      undefined,
+      { signal: options.abortSignal },
       expectedInputs,
       systemPrompt || undefined,
     );
 
-    const rawResponse = await session.prompt(messages, promptOptions);
+    const promptCallOptions = {
+      ...promptOptions,
+      signal: options.abortSignal,
+    };
+
+    const rawResponse = await session.prompt(messages, promptCallOptions);
 
     // Parse JSON tool calls from response
     const { toolCalls, textContent } = parseJsonFunctionCalls(rawResponse);
@@ -395,7 +400,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
     );
 
     const session = await this.getSession(
-      undefined,
+      { signal: options.abortSignal },
       expectedInputs,
       systemPrompt || undefined,
     );

--- a/packages/vercel/core/test/browser-ai-language-model.test.ts
+++ b/packages/vercel/core/test/browser-ai-language-model.test.ts
@@ -881,6 +881,211 @@ Running the tool now.`;
     });
   });
 
+  describe("abort signal handling", () => {
+    it("should forward abortSignal to LanguageModel.create during doGenerate", async () => {
+      const model = new BrowserAIChatLanguageModel("text");
+      const abortController = new AbortController();
+      abortController.abort();
+
+      mockPrompt.mockResolvedValue("unexpected success");
+
+      LanguageModel.create = vi.fn((options: LanguageModelCreateOptions) => {
+        if (
+          options.signal === abortController.signal &&
+          options.signal.aborted
+        ) {
+          return Promise.reject(new Error("create aborted"));
+        }
+
+        return Promise.resolve(mockSession);
+      });
+
+      await expect(
+        model.doGenerate({
+          prompt: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "Say hello" }],
+            },
+          ],
+          abortSignal: abortController.signal,
+        }),
+      ).rejects.toThrow("create aborted");
+
+      expect(LanguageModel.create).toHaveBeenCalledTimes(1);
+      expect(LanguageModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signal: abortController.signal,
+        }),
+      );
+      expect(mockPrompt).not.toHaveBeenCalled();
+    });
+
+    it("should forward abortSignal to session.prompt during doGenerate", async () => {
+      const model = new BrowserAIChatLanguageModel("text");
+
+      await model.createSessionWithProgress();
+      expect(LanguageModel.create).toHaveBeenCalledTimes(1);
+
+      mockPrompt.mockClear();
+      vi.mocked(LanguageModel.create).mockClear();
+
+      const abortController = new AbortController();
+      abortController.abort();
+
+      mockPrompt.mockImplementation(
+        (
+          _messages: LanguageModelPrompt,
+          options?: LanguageModelPromptOptions,
+        ) =>
+          options?.signal === abortController.signal && options.signal.aborted
+            ? Promise.reject(new Error("prompt aborted"))
+            : Promise.resolve("unexpected success"),
+      );
+
+      await expect(
+        model.doGenerate({
+          prompt: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "Say hello" }],
+            },
+          ],
+          abortSignal: abortController.signal,
+        }),
+      ).rejects.toThrow("prompt aborted");
+
+      expect(LanguageModel.create).not.toHaveBeenCalled();
+      expect(mockPrompt).toHaveBeenCalledTimes(1);
+      expect(mockPrompt).toHaveBeenCalledWith(
+        [
+          {
+            role: "user",
+            content: [{ type: "text", value: "Say hello" }],
+          },
+        ],
+        expect.objectContaining({
+          signal: abortController.signal,
+        }),
+      );
+    });
+
+    it("should forward abortSignal to LanguageModel.create during doStream", async () => {
+      const model = new BrowserAIChatLanguageModel("text");
+      const abortController = new AbortController();
+      abortController.abort();
+
+      LanguageModel.create = vi.fn((options: LanguageModelCreateOptions) => {
+        if (
+          options.signal === abortController.signal &&
+          options.signal.aborted
+        ) {
+          return Promise.reject(new Error("create aborted"));
+        }
+
+        return Promise.resolve(mockSession);
+      });
+
+      await expect(
+        model.doStream({
+          prompt: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "Say hello" }],
+            },
+          ],
+          abortSignal: abortController.signal,
+        }),
+      ).rejects.toThrow("create aborted");
+
+      expect(LanguageModel.create).toHaveBeenCalledTimes(1);
+      expect(LanguageModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signal: abortController.signal,
+        }),
+      );
+      expect(mockPromptStreaming).not.toHaveBeenCalled();
+    });
+
+    it("should forward abortSignal to session.promptStreaming during doStream", async () => {
+      const model = new BrowserAIChatLanguageModel("text");
+
+      await model.createSessionWithProgress();
+      expect(LanguageModel.create).toHaveBeenCalledTimes(1);
+
+      mockPromptStreaming.mockClear();
+      vi.mocked(LanguageModel.create).mockClear();
+
+      const abortController = new AbortController();
+      abortController.abort();
+
+      mockPromptStreaming.mockImplementation(
+        (
+          _messages: LanguageModelPrompt,
+          options?: LanguageModelPromptOptions,
+        ) => {
+          if (
+            options?.signal === abortController.signal &&
+            options.signal.aborted
+          ) {
+            return new ReadableStream<string>({
+              start(controller) {
+                controller.error(new Error("promptStreaming aborted"));
+              },
+            });
+          }
+          return new ReadableStream<string>({
+            start(controller) {
+              controller.enqueue("unexpected success");
+              controller.close();
+            },
+          });
+        },
+      );
+
+      const { stream } = await model.doStream({
+        prompt: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Say hello" }],
+          },
+        ],
+        abortSignal: abortController.signal,
+      });
+
+      const events: LanguageModelV3StreamPart[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      const errorEvent = events.find((e) => e.type === "error") as Extract<
+        LanguageModelV3StreamPart,
+        { type: "error" }
+      >;
+      expect(errorEvent).toBeDefined();
+      expect((errorEvent.error as Error).message).toBe(
+        "promptStreaming aborted",
+      );
+
+      expect(LanguageModel.create).not.toHaveBeenCalled();
+      expect(mockPromptStreaming).toHaveBeenCalledTimes(1);
+      expect(mockPromptStreaming).toHaveBeenCalledWith(
+        [
+          {
+            role: "user",
+            content: [{ type: "text", value: "Say hello" }],
+          },
+        ],
+        expect.objectContaining({
+          signal: abortController.signal,
+        }),
+      );
+    });
+  });
+
   describe("createSessionWithProgress", () => {
     let mockEventTarget: {
       addEventListener: ReturnType<typeof vi.fn>;


### PR DESCRIPTION
# fix(@browser-ai/core): forward abort signals to browser AI

Forwards `abortSignal` from `doGenerate` and `doStream` to both session creation and the prompt call, allowing in-flight requests to be cancelled at either stage.

## Problem

Previously, `abortSignal` was not passed to `LanguageModel.create` or `session.prompt` / `session.promptStreaming`. Cancelling a request (e.g. user navigation, timeout) had no effect on the underlying browser AI work, causing resource leaks and stale responses.

## Changes

- Pass `{ signal: options.abortSignal }` to `getSession` in both `doGenerate` and `doStream` so session creation can be aborted early
- Spread `signal` into prompt call options for `doGenerate` (`doStream` already had this for `promptStreaming`)
- Add tests covering abort at session creation and at the prompt call for both `doGenerate` and `doStream`