### PR TITLE
fix: move topK and temperature from per-prompt to session-level options

### DIFF
--- a/.changeset/violet-bushes-tell.md
+++ b/.changeset/violet-bushes-tell.md
@@ -1,0 +1,5 @@
+---
+"@browser-ai/core": patch
+---
+
+fix: move topK and temperature from per-prompt to session-level options

--- a/package-lock.json
+++ b/package-lock.json
@@ -7530,9 +7530,9 @@
       "license": "MIT"
     },
     "node_modules/@types/dom-chromium-ai": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@types/dom-chromium-ai/-/dom-chromium-ai-0.0.15.tgz",
-      "integrity": "sha512-DHHYK3/PRbkjIClaQ9VGfi2JNAT/zpG3TCtaq1cMXrdIge9xOw0Qb+yi0csNpo0dGEnbmP4zE/ZslUH0CvYCWQ==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@types/dom-chromium-ai/-/dom-chromium-ai-0.0.16.tgz",
+      "integrity": "sha512-Z0vOBWckovkc85zctYKGEUUBHaqt9Oz8AUhAVyoNLAsMGlBhMNl/8w1n8JG1y0g7TW03EzWt5RsdcDD70ra58g==",
       "dev": true,
       "license": "MIT"
     },
@@ -20964,7 +20964,7 @@
       },
       "devDependencies": {
         "@browser-ai/shared": "*",
-        "@types/dom-chromium-ai": "^0.0.15",
+        "@types/dom-chromium-ai": "^0.0.16",
         "@types/node": "^25.2.3",
         "@vitest/coverage-v8": "^4.0.18",
         "jsdom": "^28.1.0",
@@ -21724,7 +21724,7 @@
     },
     "packages/vercel/transformers-js": {
       "name": "@browser-ai/transformers-js",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@browser-ai/shared": "*",

--- a/packages/vercel/core/package.json
+++ b/packages/vercel/core/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@browser-ai/shared": "*",
-    "@types/dom-chromium-ai": "^0.0.15",
+    "@types/dom-chromium-ai": "^0.0.16",
     "@types/node": "^25.2.3",
     "@vitest/coverage-v8": "^4.0.18",
     "jsdom": "^28.1.0",

--- a/packages/vercel/core/src/chat/browser-ai-language-model.ts
+++ b/packages/vercel/core/src/chat/browser-ai-language-model.ts
@@ -166,8 +166,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
     const { systemMessage, messages } = convertToBrowserAIMessages(prompt);
 
     // Handle response format for Prompt API
-    const promptOptions: LanguageModelPromptOptions &
-      LanguageModelCreateCoreOptions = {};
+    const promptOptions: LanguageModelPromptOptions = {};
     if (responseFormat?.type === "json") {
       promptOptions.responseConstraint = responseFormat.schema as Record<
         string,
@@ -176,12 +175,13 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
     }
 
     // Map supported settings
+    const sessionOptions: LanguageModelCreateCoreOptions = {};
     if (temperature !== undefined) {
-      promptOptions.temperature = temperature;
+      sessionOptions.temperature = temperature;
     }
 
     if (topK !== undefined) {
-      promptOptions.topK = topK;
+      sessionOptions.topK = topK;
     }
 
     return {
@@ -189,6 +189,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
       messages,
       warnings,
       promptOptions,
+      sessionOptions,
       hasMultiModalInput,
       expectedInputs,
       functionTools,
@@ -211,6 +212,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
       messages,
       warnings,
       promptOptions,
+      sessionOptions,
       expectedInputs,
       functionTools,
     } = converted;
@@ -224,7 +226,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
     );
 
     const session = await this.getSession(
-      { signal: options.abortSignal },
+      { ...sessionOptions, signal: options.abortSignal },
       expectedInputs,
       systemPrompt || undefined,
     );
@@ -386,6 +388,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
       messages,
       warnings,
       promptOptions,
+      sessionOptions,
       expectedInputs,
       functionTools,
     } = converted;
@@ -400,7 +403,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
     );
 
     const session = await this.getSession(
-      { signal: options.abortSignal },
+      { ...sessionOptions, signal: options.abortSignal },
       expectedInputs,
       systemPrompt || undefined,
     );


### PR DESCRIPTION
## Summary
- Per the new updated Prompt API spec, `topK` and `temperature` belong on `LanguageModelCreateCoreOptions` (session creation), not `LanguageModelPromptOptions` (per-prompt). Previously these were passed to `session.prompt()`/`session.promptStreaming()` where the native API silently ignores them.

Moved both parameters into `sessionOptions` which flows through `getSession()` → `LanguageModel.create()` where they actually take effect.