### PR TITLE
fix(@browser-ai/core): use valid SPDX license identifier Apache-2.0

### DIFF
--- a/.changeset/proud-glasses-divide.md
+++ b/.changeset/proud-glasses-divide.md
@@ -1,0 +1,6 @@
+---
+"@browser-ai/web-llm": patch
+"@browser-ai/core": patch
+---
+
+Use valid SPDX license identifier Apache-2.0

--- a/packages/vercel/core/package.json
+++ b/packages/vercel/core/package.json
@@ -49,7 +49,7 @@
     "tool-calling",
     "function-calling"
   ],
-  "license": "Apache License",
+  "license": "Apache-2.0",
   "dependencies": {
     "@mediapipe/tasks-text": "^0.10.22-rc.20250304"
   },

--- a/packages/vercel/web-llm/package.json
+++ b/packages/vercel/web-llm/package.json
@@ -50,7 +50,7 @@
     "inference",
     "built-in-ai"
   ],
-  "license": "Apache License",
+  "license": "Apache-2.0",
   "peerDependencies": {
     "@mlc-ai/web-llm": "^0.2.79",
     "ai": "^6.0.0"


### PR DESCRIPTION
## Summary

The `license` field in `@browser-ai/core` and `@browser-ai/web-llm` is set to `"Apache License"`, which is not a valid SPDX expression. Tools like `webpack-license-plugin` fail when bundling projects that depend on these packages: `ERROR in WebpackLicensePlugin: License "Apache License" for @browser-ai/core@2.1.12 is not a valid SPDX expression!`

This changes the license field to `"Apache-2.0"`, which matches the repo's `LICENSE` file (Apache License, Version 2.0) and is consistent with `@browser-ai/transformers-js`, which already uses `"Apache-2.0"`.

## Changes
- `packages/vercel/core/package.json`: `"Apache License"` → `"Apache-2.0"`
- `packages/vercel/web-llm/package.json`: `"Apache License"` → `"Apache-2.0"`

## Test plan
- [x] Verified `"Apache-2.0"` is a valid SPDX identifier
- [x] Matches root `LICENSE` file content
- [x] Aligns with `@browser-ai/transformers-js` package.json