### PR TITLE
feat: migrate providers to ai sdk v7

### DIFF
--- a/.changeset/tame-ducks-draw.md
+++ b/.changeset/tame-ducks-draw.md
@@ -1,0 +1,7 @@
+---
+"@browser-ai/transformers-js": major
+"@browser-ai/web-llm": major
+"@browser-ai/core": major
+---
+
+feat: update to ai sdk v7

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ For detailed documentation, browser requirements and advanced usage, refer to th
 
 ### Package Versions
 
-| Package                       | AI SDK v5 |  AI SDK v6  |
-| ----------------------------- | :-------: | :---------: |
-| `@browser-ai/core`            | ✓ `1.0.0` | ✓ `≥ 2.0.0` |
-| `@browser-ai/transformers-js` | ✓ `1.0.0` | ✓ `≥ 2.0.0` |
-| `@browser-ai/web-llm`         | ✓ `1.0.0` | ✓ `≥ 2.0.0` |
+| Package                       | AI SDK v5 | AI SDK v6 |  AI SDK v7  |
+| ----------------------------- | :-------: | :-------: | :---------: |
+| `@browser-ai/core`            | ✓ `1.0.0` |  ✓ `2.x`  | ✓ `≥ 3.0.0` |
+| `@browser-ai/transformers-js` | ✓ `1.0.0` |  ✓ `2.x`  | ✓ `≥ 3.0.0` |
+| `@browser-ai/web-llm`         | ✓ `1.0.0` |  ✓ `2.x`  | ✓ `≥ 3.0.0` |
 
 ```bash
 # For Chrome/Edge built-in browser AI models
@@ -111,7 +111,7 @@ Contributions are more than welcome! However, please make sure to check out the 
 
 If you've ever built apps with local language models, you're likely familiar with the challenges: creating custom hooks, UI components and state management (lots of it), while also building complex integration layers to fall back to server-side models when compatibility is an issue.
 
-Read more about this [here](https://www.browser-ai.dev/docs/ai-sdk-v6).
+Read more about this [here](https://www.browser-ai.dev/docs/ai-sdk-v7).
 
 ## Author
 

--- a/docs/content/docs/ai-sdk-v5/index.mdx
+++ b/docs/content/docs/ai-sdk-v5/index.mdx
@@ -4,7 +4,7 @@ description: Introduction to using @browser-ai packages with Vercel AI SDK v5
 ---
 
 <Callout type="info">
-  This documentation covers packages compatible with AI SDK v5. For AI SDK v6 documentation, please visit the [AI SDK v6 section](/docs/ai-sdk-v6).
+  This documentation covers packages compatible with AI SDK v5. For newer versions, see the [AI SDK v6 section](/docs/ai-sdk-v6) or the [AI SDK v7 section](/docs/ai-sdk-v7).
 </Callout>
 
 ## Package Versions for AI SDK v5

--- a/docs/content/docs/ai-sdk-v6/transformers-js/installation.mdx
+++ b/docs/content/docs/ai-sdk-v6/transformers-js/installation.mdx
@@ -6,7 +6,7 @@ description: Setup @browser-ai/transformers-js for AI SDK v6
 ## Package Installation
 
 ```bash
-npm i @browser-ai/transformers-js
+npm i @browser-ai/transformers-js@2
 ```
 
 ## Version Compatibility

--- a/docs/content/docs/ai-sdk-v6/web-llm/installation.mdx
+++ b/docs/content/docs/ai-sdk-v6/web-llm/installation.mdx
@@ -6,7 +6,7 @@ description: Setup @browser-ai/web-llm for AI SDK v6
 ## Package Installation
 
 ```bash
-npm i @browser-ai/web-llm
+npm i @browser-ai/web-llm@2
 ```
 
 ## Version Compatibility

--- a/docs/content/docs/ai-sdk-v7/core/agents.mdx
+++ b/docs/content/docs/ai-sdk-v7/core/agents.mdx
@@ -1,0 +1,52 @@
+---
+title: Agents
+description: Build autonomous AI agents with @browser-ai/core and AI SDK v7
+---
+
+## Basic Agent Example
+
+Create an agent that can search the web and analyze content:
+
+```typescript
+import { ToolLoopAgent, isStepCount, tool } from "ai";
+import { browserAI } from "@browser-ai/core";
+import { z } from "zod";
+
+const weatherAgent = new ToolLoopAgent({
+  model: browserAI(),
+  instructions: "You are a weather assistant.",
+  tools: {
+    weather: tool({
+      description: "Get the weather in a location (in Fahrenheit)",
+      inputSchema: z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10,
+      }),
+    }),
+    convertFahrenheitToCelsius: tool({
+      description: "Convert temperature from Fahrenheit to Celsius",
+      inputSchema: z.object({
+        temperature: z.number().describe("Temperature in Fahrenheit"),
+      }),
+      execute: async ({ temperature }) => {
+        const celsius = Math.round((temperature - 32) * (5 / 9));
+        return { celsius };
+      },
+    }),
+  },
+  // Agent's default behavior is to stop after a maximum of 20 steps
+  // stopWhen: isStepCount(20),
+});
+
+const result = await weatherAgent.generate({
+  prompt: "What is the weather in San Francisco in celsius?",
+});
+
+console.log(result.text); // agent's final answer
+console.log(result.steps); // steps taken by the agent
+```
+
+Check the [Vercel documentation](https://ai-sdk.dev/docs/agents/overview) for more information.

--- a/docs/content/docs/ai-sdk-v7/core/api-reference.mdx
+++ b/docs/content/docs/ai-sdk-v7/core/api-reference.mdx
@@ -1,0 +1,111 @@
+---
+title: API Reference
+description: Complete API documentation for @browser-ai/core with AI SDK v7
+---
+
+## Provider Functions
+
+### `browserAI(modelId?, settings?)`
+
+Creates a browser AI model instance for chat.
+
+**Parameters:**
+
+- `modelId` (optional): The model identifier, defaults to `'text'`
+- `settings` (optional): Configuration options
+  - `temperature?: number` - Controls randomness (0-1)
+  - `topK?: number` - Limits vocabulary selection
+  - `onContextOverflow?: (event: Event) => void` - Callback for when the model context window is exceeded
+
+**Returns:** `BrowserAIChatLanguageModel`
+
+### `browserAI.textEmbedding(modelId, settings?)`
+
+Creates an embedding model instance.
+
+**Parameters:**
+
+- `modelId`: Must be `'embedding'`
+- `settings` (optional): Configuration options
+  - `wasmLoaderPath?: string` - Path to WASM loader (default: CDN hosted)
+  - `wasmBinaryPath?: string` - Path to WASM binary (default: CDN hosted)
+  - `modelAssetPath?: string` - Path to model asset file (default: CDN hosted)
+  - `l2Normalize?: boolean` - Normalize with L2 norm (default: false)
+  - `quantize?: boolean` - Quantize embeddings to bytes (default: false)
+  - `delegate?: 'CPU' | 'GPU'` - Backend for inference
+
+**Returns:** `BrowserAIEmbeddingModel`
+
+---
+
+## Utility Functions
+
+### `doesBrowserSupportBrowserAI()`
+
+Quick check if the browser supports the browser AI API. Useful for component-level decisions and feature flags.
+
+**Returns:** `boolean` - `true` if browser supports the Prompt API, `false` otherwise
+
+---
+
+## Model Methods
+
+### `BrowserAIChatLanguageModel.availability()`
+
+Checks the current availability status of the browser AI model.
+
+**Returns:** `Promise<"unavailable" | "downloadable" | "downloading" | "available">`
+
+| Status           | Description                                         |
+| ---------------- | --------------------------------------------------- |
+| `"unavailable"`  | Model is not supported in the browser               |
+| `"downloadable"` | Model is supported but needs to be downloaded first |
+| `"downloading"`  | Model is currently being downloaded                 |
+| `"available"`    | Model is ready to use                               |
+
+### `BrowserAIChatLanguageModel.createSessionWithProgress(onProgress?)`
+
+Creates a language model session with optional download progress monitoring.
+
+**Parameters:**
+
+- `onDownloadProgress?: (progress: number) => void` - Optional callback that receives progress values from 0 to 1 during model download
+
+**Returns:** `Promise<BrowserAIChatLanguageModel>` - The configured language model instance
+
+### `BrowserAIChatLanguageModel.getContextUsage()`
+
+Gets the current context usage (tokens consumed) of the current session. If the session is not available returns undefined.
+
+**Returns:** `number | undefined`
+
+### `BrowserAIChatLanguageModel.getContextWindow()`
+
+Gets the context window size (token limit) of the current session. If the session is not available returns undefined.
+
+**Returns:** `number | undefined`
+
+---
+
+## Types
+
+### `BrowserAIUIMessage`
+
+Extended UI message type for use with the `useChat` hook that includes custom data parts for browser AI functionality.
+
+```typescript
+type BrowserAIUIMessage = UIMessage<
+  never,
+  {
+    modelDownloadProgress: {
+      status: "downloading" | "complete" | "error";
+      progress?: number;
+      message: string;
+    };
+    notification: {
+      message: string;
+      level: "info" | "warning" | "error";
+    };
+  }
+>;
+```

--- a/docs/content/docs/ai-sdk-v7/core/index.mdx
+++ b/docs/content/docs/ai-sdk-v7/core/index.mdx
@@ -1,0 +1,53 @@
+---
+title: "Overview"
+description: Browser AI model provider for Vercel AI SDK v7 (Chrome & Edge)
+---
+
+The `@browser-ai/core` package enables you to leverage [Chrome and Edge's](https://github.com/webmachinelearning/prompt-api) native AI models directly in the browser with seamless integration with the Vercel AI SDK v7.
+
+### Key Features
+
+- **Zero-latency inference**: Models run locally in the browser
+- **Privacy-first**: Data never leaves the user's device
+- **Offline capable**: Works without internet after initial model download
+- **Seamless fallback**: Easy integration with server-side models
+- **Agent support**: Build AI agents with tool calling support
+
+### What's Included
+
+- **Language Models**: Text generation with Gemini Nano (Chrome) or Phi Mini (Edge)
+- **Text Embeddings**: Generate embeddings using browser-native models
+- **Multimodal Support**: Image and audio input (Chrome only)
+- **Tool Calling**: Function calling with JSON format support
+- **Structured Output**: Generate validated JSON objects
+- **Agents**: Multi-step autonomous workflows
+
+## Quick Links
+
+<Cards>
+  <Card
+    title="Installation"
+    href="/docs/ai-sdk-v7/core/installation"
+    description="Setup and browser requirements"
+  />
+  <Card
+    title="Usage"
+    href="/docs/ai-sdk-v7/core/usage"
+    description="Features and usage examples"
+  />
+  <Card
+    title="useChat Integration"
+    href="/docs/ai-sdk-v7/core/usechat-integration"
+    description="React hook integration"
+  />
+  <Card
+    title="Agents"
+    href="/docs/ai-sdk-v7/core/agents"
+    description="Build autonomous AI agents"
+  />
+  <Card
+    title="API Reference"
+    href="/docs/ai-sdk-v7/core/api-reference"
+    description="Complete API documentation"
+  />
+</Cards>

--- a/docs/content/docs/ai-sdk-v7/core/installation.mdx
+++ b/docs/content/docs/ai-sdk-v7/core/installation.mdx
@@ -1,23 +1,26 @@
 ---
 title: Installation
-description: Setup @browser-ai/core for AI SDK v6
+description: Setup @browser-ai/core for AI SDK v7
 ---
 
 ## Package Installation
 
 ```bash
-npm i @browser-ai/core@2
+npm i @browser-ai/core
 ```
 
 ## Version Compatibility
 
-| @browser-ai/core | AI SDK | Notes |
-|-------------------|--------|-------|
-| v2.0.0 and above | v6.x | Current stable for AI SDK v6 |
-| v1.0.0 | v5.x | Use for AI SDK v5 |
+| @browser-ai/core | AI SDK | Notes                        |
+| ---------------- | ------ | ---------------------------- |
+| v3.0.0 and above | v7.x   | Current stable for AI SDK v7 |
+| v2.x             | v6.x   | Use for AI SDK v6            |
+| v1.0.0           | v5.x   | Use for AI SDK v5            |
 
 <Callout type="info">
-  For AI SDK v5, please refer to the [v5 documentation](/docs/ai-sdk-v5/core/installation).
+  For AI SDK v6, please refer to the [v6
+  documentation](/docs/ai-sdk-v6/core/installation), and for AI SDK v5 the [v5
+  documentation](/docs/ai-sdk-v5/core/installation).
 </Callout>
 
 ### Edge Setup
@@ -42,4 +45,3 @@ if (doesBrowserSupportBrowserAI()) {
   console.log("Browser AI not available, use server fallback");
 }
 ```
-

--- a/docs/content/docs/ai-sdk-v7/core/meta.json
+++ b/docs/content/docs/ai-sdk-v7/core/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "@browser-ai/core",
+  "description": "Browser AI provider (Chrome & Edge)",
+  "icon": "Cpu",
+  "pages": [
+    "index",
+    "installation",
+    "usage",
+    "usechat-integration",
+    "agents",
+    "api-reference"
+  ]
+}

--- a/docs/content/docs/ai-sdk-v7/core/usage.mdx
+++ b/docs/content/docs/ai-sdk-v7/core/usage.mdx
@@ -1,0 +1,232 @@
+---
+title: Usage
+description: Features and usage examples for @browser-ai/core with AI SDK v7
+---
+
+## Basic Text Generation
+
+### Streaming Text
+
+```typescript
+import { streamText } from "ai";
+import { browserAI } from "@browser-ai/core";
+
+const result = streamText({
+  model: browserAI(),
+  prompt: "Invent a new holiday and describe its traditions.",
+});
+
+for await (const textPart of result.textStream) {
+  console.log(textPart);
+}
+```
+
+### Non-streaming Text
+
+```typescript
+import { generateText } from "ai";
+import { browserAI } from "@browser-ai/core";
+
+const result = await generateText({
+  model: browserAI(),
+  prompt: "Invent a new holiday and describe its traditions.",
+});
+
+console.log(result.text);
+```
+
+## Text Embeddings
+
+Generate text embeddings using browser-native embedding capabilities:
+
+```typescript
+import { embed, embedMany } from "ai";
+import { browserAI } from "@browser-ai/core";
+
+// Single embedding
+const { embedding, usage } = await embed({
+  model: browserAI.embedding("embedding"),
+  value: "Hello, world!",
+});
+
+// Multiple embeddings
+const { embedding, usage } = await embedMany({
+  model: browserAI.embedding("embedding"),
+  values: ["Hello", "World", "AI"],
+});
+```
+
+## Download Progress Tracking
+
+When using browser AI models for the first time, the model needs to be downloaded. Track progress to improve UX:
+
+```typescript
+import { streamText } from "ai";
+import { browserAI } from "@browser-ai/core";
+
+const model = browserAI();
+const availability = await model.availability();
+
+if (availability === "unavailable") {
+  console.log("Browser doesn't support built-in AI");
+  return;
+}
+
+if (availability === "downloadable") {
+  await model.createSessionWithProgress((progress) => {
+    console.log(`Download progress: ${Math.round(progress * 100)}%`);
+  });
+}
+
+// Model is ready
+const result = streamText({
+  model,
+  prompt: "Invent a new holiday and describe its traditions.",
+});
+```
+
+## Multimodal Support
+
+The Prompt API supports both images and audio files (currently only Chrome):
+
+```typescript
+import { streamText } from "ai";
+import { browserAI } from "@browser-ai/core";
+
+const result = streamText({
+  model: browserAI(),
+  messages: [
+    {
+      // Image
+      role: "user",
+      content: [
+        { type: "text", text: "What's in this image?" },
+        { type: "file", mediaType: "image/png", data: base64ImageData },
+      ],
+    },
+    {
+      // Audio
+      role: "user",
+      content: [{ type: "file", mediaType: "audio/mp3", data: audioData }],
+    },
+  ],
+});
+
+for await (const chunk of result.textStream) {
+  console.log(chunk);
+}
+```
+
+## Tool Calling
+
+The `browserAI` model supports tool calling with multi-step execution:
+
+```typescript
+import { streamText, isStepCount } from "ai";
+import { browserAI } from "@browser-ai/core";
+import { z } from "zod";
+
+const result = await streamText({
+  model: browserAI(),
+  messages: [{ role: "user", content: "What's the weather in San Francisco?" }],
+  tools: {
+    weather: tool({
+      description: "Get the weather in a location",
+      inputSchema: z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10,
+      }),
+    }),
+  },
+  stopWhen: isStepCount(5), // multiple steps
+});
+```
+
+It also supports [tool execution approval](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#tool-execution-approval), which in AI SDK v7 is configured with the `toolApproval` option on the call (or agent) instead of `needsApproval` on the tool.
+
+## Tool Calling with Structured Output
+
+```ts
+import { Output, ToolLoopAgent, tool } from "ai";
+import { browserAI } from "@browser-ai/core";
+import { z } from "zod";
+
+const agent = new ToolLoopAgent({
+  model: browserAI(),
+  tools: {
+    weather: tool({
+      description: "Get the weather in a location",
+      inputSchema: z.object({ city: z.string() }),
+      execute: async ({ city }) => {
+        // ...
+      },
+    }),
+  },
+  output: Output.object({
+    schema: z.object({
+      summary: z.string(),
+      temperature: z.number(),
+      recommendation: z.string(),
+    }),
+  }),
+});
+
+const { output } = await agent.generate({
+  prompt: "What is the weather in San Francisco and what should I wear?",
+});
+```
+
+## Structured Output
+
+Generate structured JSON output with schema validation:
+
+### Using generateText
+
+```typescript
+import { generateText } from "ai";
+import { browserAI } from "@browser-ai/core";
+import { z } from "zod";
+
+const { output } = await generateText({
+  model: browserAI(),
+  output: Output.object({
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({ name: z.string(), amount: z.string() }),
+        ),
+        steps: z.array(z.string()),
+      }),
+    }),
+  }),
+  prompt: "Generate a lasagna recipe.",
+});
+```
+
+### Using streamText
+
+```typescript
+import { streamText } from "ai";
+import { browserAI } from "@browser-ai/core";
+import { z } from "zod";
+
+const { partialOutputStream } = streamText({
+  model: browserAI(),
+  output: Output.object({
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({ name: z.string(), amount: z.string() }),
+        ),
+        steps: z.array(z.string()),
+      }),
+    }),
+  }),
+  prompt: "Generate a lasagna recipe.",
+});
+```

--- a/docs/content/docs/ai-sdk-v7/core/usechat-integration.mdx
+++ b/docs/content/docs/ai-sdk-v7/core/usechat-integration.mdx
@@ -1,3 +1,16 @@
+---
+title: useChat Integration
+description: Integrate @browser-ai/core with the useChat hook in AI SDK v7
+---
+
+## Overview
+
+When using this library with the `useChat` hook, you'll need to create a [custom transport](https://ai-sdk.dev/docs/ai-sdk-ui/transport) implementation to handle client-side AI with download progress.
+This is not required, but it makes it easier for you to build better user experiences.
+
+## Complete Transport Example
+
+```ts
 import {
   ChatTransport,
   UIMessageChunk,
@@ -5,13 +18,15 @@ import {
   convertToModelMessages,
   ChatRequestOptions,
   createUIMessageStream,
-  wrapLanguageModel,
-  extractReasoningMiddleware,
   tool,
   isStepCount,
   toUIMessageStream,
 } from "ai";
-import { WebLLMUIMessage, WebLLMLanguageModel } from "@browser-ai/web-llm";
+import {
+  browserAI,
+  BrowserAIChatLanguageModel,
+  BrowserAIUIMessage,
+} from "@browser-ai/core";
 import z from "zod";
 
 export const createTools = () => ({
@@ -24,50 +39,7 @@ export const createTools = () => ({
         .describe("The search query to find information on the web"),
     }),
     execute: async ({ query }) => {
-      try {
-        // Call the API route instead of Exa directly
-        const response = await fetch("/api/web-search", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ query }),
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json();
-          return errorData.error || "Failed to search the web";
-        }
-
-        const result = await response.json();
-        return result;
-      } catch (err) {
-        return `Failed to search the web: ${err instanceof Error ? err.message : "Unknown error"}`;
-      }
-    },
-  }),
-  getCurrentTime: tool({
-    description:
-      "Get the current date and time. Use this when the user asks about the current time, date, or day of the week.",
-    inputSchema: z.object({}),
-    execute: async () => {
-      const now = new Date();
-      return {
-        timestamp: now.toISOString(),
-        date: now.toLocaleDateString("en-US", {
-          weekday: "long",
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        }),
-        time: now.toLocaleTimeString("en-US", {
-          hour: "2-digit",
-          minute: "2-digit",
-          second: "2-digit",
-          hour12: true,
-        }),
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      };
+      // ...
     },
   }),
 });
@@ -76,21 +48,23 @@ export const createTools = () => ({
  * Client-side chat transport AI SDK implementation that handles AI model communication
  * with in-browser AI capabilities.
  *
- * @implements {ChatTransport<WebLLMUIMessage>}
+ * @implements {ChatTransport<BrowserAIUIMessage>}
  */
-export class WebLLMChatTransport implements ChatTransport<WebLLMUIMessage> {
-  private readonly model: WebLLMLanguageModel;
+export class ClientSideChatTransport implements ChatTransport<BrowserAIUIMessage> {
   private tools: ReturnType<typeof createTools>;
+  private model: BrowserAIChatLanguageModel;
 
-  constructor(model: WebLLMLanguageModel) {
-    this.model = model;
+  constructor() {
     this.tools = createTools();
+    this.model = browserAI("text", {
+      expectedInputs: [{ type: "text" }, { type: "image" }, { type: "audio" }],
+    });
   }
 
   async sendMessages(
     options: {
       chatId: string;
-      messages: WebLLMUIMessage[];
+      messages: BrowserAIUIMessage[];
       abortSignal: AbortSignal | undefined;
     } & {
       trigger: "submit-message" | "submit-tool-result" | "regenerate-message";
@@ -99,16 +73,15 @@ export class WebLLMChatTransport implements ChatTransport<WebLLMUIMessage> {
   ): Promise<ReadableStream<UIMessageChunk>> {
     const { messages, abortSignal } = options;
     const prompt = await convertToModelMessages(messages);
-    const model = this.model;
 
-    return createUIMessageStream<WebLLMUIMessage>({
+    return createUIMessageStream<BrowserAIUIMessage>({
       execute: async ({ writer }) => {
         let downloadProgressId: string | undefined;
-        const availability = await model.availability();
+        const availability = await this.model.availability();
 
         // Only track progress if model needs downloading
         if (availability !== "available") {
-          await model.createSessionWithProgress((progress) => {
+          await this.model.createSessionWithProgress((progress) => {
             const percent = Math.round(progress * 100);
 
             if (progress >= 1) {
@@ -145,14 +118,10 @@ export class WebLLMChatTransport implements ChatTransport<WebLLMUIMessage> {
         }
 
         const result = streamText({
-          model: wrapLanguageModel({
-            model,
-            middleware: extractReasoningMiddleware({
-              tagName: "think",
-            }),
-          }),
+          model: this.model,
           tools: this.tools,
           stopWhen: isStepCount(5),
+          // In AI SDK v7, approval moved out of `tool()` and onto the call
           toolApproval: {
             webSearch: "user-approval",
           },
@@ -190,3 +159,87 @@ export class WebLLMChatTransport implements ChatTransport<WebLLMUIMessage> {
     return null;
   }
 }
+```
+
+## Basic Transport Structure
+
+Here's a simplified example of how to structure a custom transport:
+
+```typescript
+import {
+  ChatTransport,
+  UIMessage,
+  UIMessageChunk,
+  streamText,
+  convertToModelMessages,
+  ChatRequestOptions,
+  toUIMessageStream,
+} from "ai";
+import { browserAI } from "@browser-ai/core";
+
+// This class won't stream back data parts with the download progress if
+// the Prompt API model hasn't yet been downloaded
+export class SimpleClientSideChatTransport implements ChatTransport<UIMessage> {
+  async sendMessages(
+    options: {
+      chatId: string;
+      messages: UIMessage[];
+      abortSignal: AbortSignal | undefined;
+    } & {
+      trigger: "submit-message" | "submit-tool-result" | "regenerate-message";
+      messageId: string | undefined;
+    } & ChatRequestOptions,
+  ): Promise<ReadableStream<UIMessageChunk>> {
+    const prompt = await convertToModelMessages(options.messages);
+
+    const result = streamText({
+      model: browserAI(),
+      messages: prompt,
+      abortSignal: options.abortSignal,
+    });
+
+    return toUIMessageStream({ stream: result.stream });
+  }
+
+  async reconnectToStream(
+    options: {
+      chatId: string;
+    } & ChatRequestOptions,
+  ): Promise<ReadableStream<UIMessageChunk> | null> {
+    // Client-side AI doesn't support stream reconnection
+    return null;
+  }
+}
+```
+
+You can then use the `useChat()` hook in your components:
+
+```ts
+const {
+    sendMessage,
+    messages,
+    stop,
+    addToolApprovalResponse,
+  } = useChat<BrowserAIUIMessage>({
+    transport: new ClientSideChatTransport(), // Pass custom transport
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+```
+
+In case the device is incompatible with local in-browser LLMs, and we want to use a server-side AI model, we can simply use the utility function from the package first:
+
+```ts
+import { doesBrowserSupportBrowserAI } from "@browser-ai/core";
+
+const {
+  sendMessage,
+    messages,
+    stop,
+    addToolApprovalResponse,
+  } = useChat<BrowserAIUIMessage>({
+    transport: doesBrowserSupportBrowserAI() // check for device compatibility
+      ? new ClientSideChatTransport()
+      : new DefaultChatTransport<UIMessage>({
+          api: "/api/chat",
+        }),
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+```

--- a/docs/content/docs/ai-sdk-v7/getting-started.mdx
+++ b/docs/content/docs/ai-sdk-v7/getting-started.mdx
@@ -1,31 +1,31 @@
 ---
 title: Getting Started
-description: Introduction to using @browser-ai packages with Vercel AI SDK v6
+description: Introduction to using @browser-ai packages with Vercel AI SDK v7
 ---
 
-<Callout type="info">
-  This documentation covers the v2 packages, which target AI SDK v6. For AI SDK v7, use the v3 packages and the [AI SDK v7 section](/docs/ai-sdk-v7).
-</Callout>
+## Package Versions for AI SDK v7
 
-## Package Versions for AI SDK v6
-
-| Package                       | AI SDK v6  |
+| Package                       |  AI SDK v7  |
 | ----------------------------- | :---------: |
-| `@browser-ai/core`            | ✓ `≥ 2.0.0` |
-| `@browser-ai/transformers-js` | ✓ `≥ 2.0.0` |
-| `@browser-ai/web-llm`         | ✓ `≥ 2.0.0` |
+| `@browser-ai/core`            | ✓ `≥ 3.0.0` |
+| `@browser-ai/transformers-js` | ✓ `≥ 3.0.0` |
+| `@browser-ai/web-llm`         | ✓ `≥ 3.0.0` |
+
+<Callout type="info">
+  Version 3 of the `@browser-ai` packages requires AI SDK `ai@^7.0.0` and Node.js `>=22`. If you are still on AI SDK v6, use the v2 packages and the [AI SDK v6 documentation](/docs/ai-sdk-v6).
+</Callout>
 
 ## Installation
 
 ```bash
 # For Chrome/Edge built-in browser AI (Prompt API)
-npm i @browser-ai/core@2
+npm i @browser-ai/core
 
 # For Transformers.js (Hugging Face models)
-npm i @browser-ai/transformers-js@2
+npm i @browser-ai/transformers-js
 
 # For WebLLM (MLC models)
-npm i @browser-ai/web-llm@2
+npm i @browser-ai/web-llm
 ```
 
 ## Available Packages
@@ -40,7 +40,7 @@ Access Chrome and Edge's built-in browser AI capabilities through the experiment
 - **Structured Data**: Generate structured data
 - **Tool Calling**: Function calling with JSON format support
 
-[View Core Documentation →](/docs/ai-sdk-v6/core)
+[View Core Documentation →](/docs/ai-sdk-v7/core)
 
 ### @browser-ai/transformers-js
 
@@ -53,7 +53,7 @@ Run [Hugging Face Transformers](https://huggingface.co/models) models directly i
 - **Transcription**: Whisper models for speech-to-text
 - **Tool Calling**: Function calling support
 
-[View Transformers.js Documentation →](/docs/ai-sdk-v6/transformers-js)
+[View Transformers.js Documentation →](/docs/ai-sdk-v7/transformers-js)
 
 ### @browser-ai/web-llm
 
@@ -64,7 +64,7 @@ High-performance in-browser LLM inference using [WebLLM](https://github.com/mlc-
 - **Web Worker Support**: Efficient background processing
 - **Tool Calling**: Function calling support
 
-[View Web-LLM Documentation →](/docs/ai-sdk-v6/web-llm)
+[View Web-LLM Documentation →](/docs/ai-sdk-v7/web-llm)
 
 ## Easy Server Fallback
 

--- a/docs/content/docs/ai-sdk-v7/index.mdx
+++ b/docs/content/docs/ai-sdk-v7/index.mdx
@@ -1,0 +1,43 @@
+---
+title: Introduction
+description: Introduction to the @browser-ai packages and Vercel AI SDK v7
+---
+
+If you've been experimenting with running local language models directly in the browser using Transformers.js, WebLLM, or the new Prompt API in Chrome/Edge, you're likely familiar with the challenges:
+
+- **Custom hooks and UI components**: Each framework requires its own integration patterns
+- **Fallback complexity**: Building robust integration layers to automatically fall back to server-side models when client-side compatibility is an issue
+- **API fragmentation**: Significant differences in API specifications across different in-browser LLM frameworks
+
+### API Fragmentation
+
+The main issue is that the ways of using in-browser LLMs are fundamentally different:
+
+- **Transformers.js** introduces its own [`pipeline`](https://huggingface.co/docs/transformers.js/en/pipelines) API, supporting a range of NLP, Computer Vision, Audio, and Multimodal tasks by leveraging ONNX Runtime
+- **WebLLM** provides an OpenAI-style API and leverages their own [MLCEngine](https://llm.mlc.ai/), WebGPU and WebAssembly for model execution
+- **The Prompt API** (utilizing Gemini Nano and Phi4-mini) offers native browser integration via the JavaScript `LanguageModel` namespace
+
+Besides these API differences, it's also tricky to easily fall back to server-side models when the client device can't run local models due to hardware limitations (e.g., insufficient VRAM) or browser compatibility issues (e.g., WebGPU still not being implemented in some browsers).
+
+## Solution
+
+The `@browser-ai` library bridges this gap by providing a unified solution that lets you:
+
+- Experiment with in-browser AI models using familiar patterns
+- Seamlessly fall back to server-side models when needed
+- Use the same Vercel AI SDK eco system you already know
+- Avoid building complex integration layers from scratch
+
+Use the different engines in the same reliable way:
+
+```typescript
+import { streamText } from "ai";
+import { browserAI } from "@browser-ai/core";
+// or: import { transformersJS } from "@browser-ai/transformers-js";
+// or: import { webLLM } from "@browser-ai/web-llm";
+
+const result = streamText({
+  model: browserAI(), // change model provider here
+  prompt: "Why is the sky blue?",
+});
+```

--- a/docs/content/docs/ai-sdk-v7/meta.json
+++ b/docs/content/docs/ai-sdk-v7/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "AI SDK v7",
+  "description": "Using @browser-ai with Vercel AI SDK v7",
+  "root": true,
+  "pages": [
+    "index",
+    "getting-started",
+    "migration",
+    "core",
+    "transformers-js",
+    "web-llm"
+  ]
+}

--- a/docs/content/docs/ai-sdk-v7/migration.mdx
+++ b/docs/content/docs/ai-sdk-v7/migration.mdx
@@ -1,0 +1,80 @@
+---
+title: Migrating to v3
+description: Upgrade the @browser-ai packages from v2 (AI SDK v6) to v3 (AI SDK v7)
+---
+
+Version 3 of the `@browser-ai` packages targets [Vercel AI SDK v7](https://ai-sdk.dev/docs/migration-guides/migration-guide-7-0). The providers themselves keep the same public surface - `browserAI()`, `transformersJS()`, `webLLM()`, their embedding/transcription models, and the download-progress helpers are unchanged. What changes is the AI SDK version you use them with.
+
+## 1. Update your dependencies
+
+```bash
+npm i ai@^7 @browser-ai/core@^3
+# and/or
+npm i @browser-ai/transformers-js@^3
+npm i @browser-ai/web-llm@^3
+```
+
+<Callout type="warn">
+  AI SDK v7 requires Node.js `>=22` and its packages are ESM-only. If you use `@ai-sdk/react`, upgrade it alongside `ai`.
+</Callout>
+
+## 2. Update your AI SDK call sites
+
+These are the AI SDK v7 changes most likely to affect code that uses `@browser-ai`:
+
+| v6                                   | v7                                                                                        |
+| ------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `system: "..."`                      | `instructions: "..."`                                                                     |
+| `stepCountIs(5)`                     | `isStepCount(5)`                                                                          |
+| `result.fullStream`                  | `result.stream`                                                                           |
+| `result.toUIMessageStream(opts)`     | `toUIMessageStream({ stream: result.stream, ...opts })`                                   |
+| `result.toUIMessageStreamResponse()` | `createUIMessageStreamResponse({ stream: toUIMessageStream({ stream: result.stream }) })` |
+| `result.toTextStreamResponse()`      | `createTextStreamResponse({ stream: toTextStream({ stream: result.stream }) })`           |
+| `onFinish` / `onStepFinish`          | `onEnd` / `onStepEnd`                                                                     |
+| `needsApproval` on `tool()`          | `toolApproval: { toolName: "user-approval" }` on the call                                 |
+| `usage.cachedInputTokens`            | `usage.inputTokenDetails.cacheReadTokens`                                                 |
+| `usage.reasoningTokens`              | `usage.outputTokenDetails.reasoningTokens`                                                |
+
+### Custom transports
+
+Custom `ChatTransport` implementations are the most common place this shows up, since they call `toUIMessageStream` directly:
+
+```ts
+// v2 / AI SDK v6
+writer.merge(result.toUIMessageStream({ sendStart: false }));
+
+// v3 / AI SDK v7
+writer.merge(
+  toUIMessageStream({
+    stream: result.stream,
+    tools: this.tools,
+    sendStart: false,
+  }),
+);
+```
+
+See the per-package [useChat integration](/docs/ai-sdk-v7/core/usechat-integration) pages for full, updated transport examples.
+
+### Multi-step results
+
+In v7, top-level result fields such as `content`, `toolCalls`, `toolResults`, and `usage` cover **all** steps. If you relied on final-step-only values, read them from `result.finalStep` instead:
+
+```ts
+const { usage, finalStep } = await generateText({ model: browserAI(), prompt });
+
+usage.totalTokens; // all steps
+finalStep.usage.totalTokens; // final step only
+finalStep.finishReason;
+```
+
+### `onChunk`
+
+`onChunk` now receives every stream part, including lifecycle, boundary, finish, abort, and error parts. Always narrow on `chunk.type` before using a part:
+
+```ts
+onChunk: (event) => {
+  if (event.chunk.type === "text-delta") {
+    // ...
+  }
+},
+```

--- a/docs/content/docs/ai-sdk-v7/transformers-js/agents.mdx
+++ b/docs/content/docs/ai-sdk-v7/transformers-js/agents.mdx
@@ -1,0 +1,57 @@
+---
+title: Agents
+description: Build autonomous AI agents with @browser-ai/transformers-js and AI SDK v7
+---
+
+## Basic Agent Example
+
+Create an agent that can search the web and analyze content:
+
+```typescript
+import { ToolLoopAgent, isStepCount, tool } from "ai";
+import { transformersJS } from "@browser-ai/transformers-js";
+import { z } from "zod";
+
+const weatherAgent = new ToolLoopAgent({
+  model: transformersJS("onnx-community/Qwen3-0.6B-ONNX"),
+  instructions: "You are a weather assistant.",
+  tools: {
+    weather: tool({
+      description: "Get the weather in a location (in Fahrenheit)",
+      inputSchema: z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10,
+      }),
+    }),
+    convertFahrenheitToCelsius: tool({
+      description: "Convert temperature from Fahrenheit to Celsius",
+      inputSchema: z.object({
+        temperature: z.number().describe("Temperature in Fahrenheit"),
+      }),
+      execute: async ({ temperature }) => {
+        const celsius = Math.round((temperature - 32) * (5 / 9));
+        return { celsius };
+      },
+    }),
+  },
+  // Agent's default behavior is to stop after a maximum of 20 steps
+  // stopWhen: isStepCount(20),
+});
+
+const result = await weatherAgent.generate({
+  prompt: "What is the weather in San Francisco in celsius?",
+});
+
+console.log(result.text); // agent's final answer
+console.log(result.steps); // steps taken by the agent
+```
+
+<Callout type="info">
+  For best agent results, use reasoning models like Qwen3 which handle
+  multi-step reasoning better.
+</Callout>
+
+Check the [Vercel documentation](https://ai-sdk.dev/docs/agents/overview) for more information.

--- a/docs/content/docs/ai-sdk-v7/transformers-js/api-reference.mdx
+++ b/docs/content/docs/ai-sdk-v7/transformers-js/api-reference.mdx
@@ -1,0 +1,176 @@
+---
+title: API Reference
+description: Complete API documentation for @browser-ai/transformers-js with AI SDK v7
+---
+
+## Provider Functions
+
+### `transformersJS(modelId, settings?)`
+
+Creates a Transformers.js language model instance.
+
+**Parameters:**
+
+- `modelId`: A Hugging Face model ID (e.g., `"HuggingFaceTB/SmolLM2-360M-Instruct"`)
+- `settings` (optional): Configuration options
+  - `device?: "auto" | "cpu" | "webgpu" | "gpu"` - Inference device (default: "auto")
+  - `dtype?: "auto" | "fp32" | "fp16" | "q8" | "q4" | "q4f16"` - Data type for model weights
+  - `isVisionModel?: boolean` - Whether this is a vision model (default: false)
+  - `worker?: Worker` - Web Worker for off-main-thread execution
+  - `initProgressCallback?: (progress: number) => void` - Progress callback
+  - `localModelPath?: string` - Path to load local models from (Node.js only)
+  - `cacheDir?: string` - Directory for caching model files (Node.js only)
+
+**Returns:** `TransformersJSLanguageModel`
+
+### `transformersJS.textEmbedding(modelId, settings?)`
+
+Creates a Transformers.js embedding model instance.
+
+**Parameters:**
+
+- `modelId`: A Hugging Face embedding model ID (e.g., `"Supabase/gte-small"`)
+- `settings` (optional): Configuration options
+  - `device?: "auto" | "cpu" | "webgpu"` - Inference device (default: "auto")
+  - `dtype?: "auto" | "fp32" | "fp16" | "q8" | "q4" | "q4f16"` - Data type
+  - `normalize?: boolean` - Normalize embeddings (default: true)
+  - `pooling?: "mean" | "cls" | "max"` - Pooling strategy (default: "mean")
+  - `maxTokens?: number` - Maximum input tokens (default: 512)
+
+**Returns:** `TransformersJSEmbeddingModel`
+
+### `transformersJS.transcription(modelId, settings?)`
+
+Creates a Transformers.js transcription model instance.
+
+**Parameters:**
+
+- `modelId`: A Hugging Face Whisper model ID (e.g., `"Xenova/whisper-base"`)
+- `settings` (optional): Configuration options
+  - `device?: "auto" | "cpu" | "webgpu"` - Inference device
+  - `dtype?: "auto" | "fp32" | "fp16" | "q8" | "q4"` - Data type
+  - `maxNewTokens?: number` - Maximum tokens to generate (default: 448)
+  - `language?: string` - Language hint for accuracy
+  - `returnTimestamps?: boolean` - Return segment timestamps (default: false)
+  - `worker?: Worker` - Web Worker for off-main-thread execution
+
+**Returns:** `TransformersJSTranscriptionModel`
+
+---
+
+## Utility Functions
+
+### `doesBrowserSupportTransformersJS()`
+
+Quick check if the browser supports Transformers.js with optimal performance.
+
+**Returns:** `boolean` - `true` if browser has WebGPU or WebAssembly support
+
+---
+
+## Model Methods
+
+### `TransformersJSLanguageModel.availability()`
+
+Checks the current availability status of the model.
+
+**Returns:** `Promise<"unavailable" | "downloadable" | "available">`
+
+| Status           | Description                                         |
+| ---------------- | --------------------------------------------------- |
+| `"unavailable"`  | Model is not supported in the environment           |
+| `"downloadable"` | Model is supported but needs to be downloaded first |
+| `"available"`    | Model is ready to use                               |
+
+### `TransformersJSLanguageModel.createSessionWithProgress(onProgress?)`
+
+Creates a language model session with optional download progress monitoring.
+
+**Parameters:**
+
+- `onProgress?: (progress: number) => void` - Callback receiving progress values from 0 to 1
+
+**Returns:** `Promise<TransformersJSLanguageModel>`
+
+### `TransformersJSEmbeddingModel.availability()`
+
+Checks current availability status for the embedding model.
+
+**Returns:** `Promise<"unavailable" | "downloadable" | "available">`
+
+### `TransformersJSEmbeddingModel.createSessionWithProgress(onProgress?)`
+
+Creates/initializes an embedding model session with optional progress monitoring.
+
+**Parameters:**
+
+- `onProgress?: (progress: number) => void`
+
+**Returns:** `Promise<TransformersJSEmbeddingModel>`
+
+### `TransformersJSTranscriptionModel.availability()`
+
+Checks current availability status for the transcription model.
+
+**Returns:** `Promise<"unavailable" | "downloadable" | "available">`
+
+### `TransformersJSTranscriptionModel.createSessionWithProgress(onProgress?)`
+
+Creates/initializes a transcription model session with optional progress monitoring.
+
+**Parameters:**
+
+- `onProgress?: (progress: number) => void`
+
+**Returns:** `Promise<TransformersJSTranscriptionModel>`
+
+---
+
+## Worker Handlers
+
+### `TransformersJSWorkerHandler`
+
+Utility handler for Web Worker usage with language models.
+
+```typescript
+import { TransformersJSWorkerHandler } from "@browser-ai/transformers-js";
+
+const handler = new TransformersJSWorkerHandler();
+self.onmessage = (msg: MessageEvent) => handler.onmessage(msg);
+```
+
+### `TransformersJSTranscriptionWorkerHandler`
+
+Utility handler for Web Worker usage with transcription models.
+
+```typescript
+import { TransformersJSTranscriptionWorkerHandler } from "@browser-ai/transformers-js";
+
+const handler = new TransformersJSTranscriptionWorkerHandler();
+self.onmessage = (msg: MessageEvent) => handler.onmessage(msg);
+```
+
+---
+
+## Types
+
+### `TransformersUIMessage`
+
+Extended UI message type for use with the `useChat` hook that includes custom data parts for Transformers.js functionality.
+
+```typescript
+type TransformersUIMessage = UIMessage<
+  never,
+  {
+    modelDownloadProgress: {
+      status: "downloading" | "complete" | "error";
+      progress?: number;
+      message: string;
+    };
+    notification: {
+      message: string;
+      level: "info" | "warning" | "error";
+    };
+  }
+>;
+```

--- a/docs/content/docs/ai-sdk-v7/transformers-js/index.mdx
+++ b/docs/content/docs/ai-sdk-v7/transformers-js/index.mdx
@@ -1,0 +1,50 @@
+---
+title: "Overview"
+description: Transformers.js provider for Vercel AI SDK v7
+---
+
+The `@browser-ai/transformers-js` package makes it incredibly easy to run inference with [Hugging Face Transformers](https://github.com/huggingface/transformers.js) models in the browser with the Vercel AI SDK v7. No complex Web Worker setup, no manual streaming.
+
+### What's Included
+
+- **Language Models**: Text generation with SmolLM, Qwen, Llama, and more
+- **Text Embeddings**: GTE, MiniLM, and other embedding models
+- **Vision Models**: SmolVLM and other multimodal models
+- **Transcription**: Whisper models for speech-to-text
+- **Tool Calling**: Function calling support
+- **Agents**: Multi-step autonomous workflows
+
+## Quick Links
+
+<Cards>
+  <Card
+    title="Why?"
+    href="/docs/ai-sdk-v7/transformers-js/why"
+    description="Increased developer experience"
+  />
+  <Card
+    title="Installation"
+    href="/docs/ai-sdk-v7/transformers-js/installation"
+    description="Setup and requirements"
+  />
+  <Card
+    title="Usage"
+    href="/docs/ai-sdk-v7/transformers-js/usage"
+    description="Features and examples"
+  />
+  <Card
+    title="useChat Integration"
+    href="/docs/ai-sdk-v7/transformers-js/usechat-integration"
+    description="React hook integration"
+  />
+  <Card
+    title="Agents"
+    href="/docs/ai-sdk-v7/transformers-js/agents"
+    description="Build autonomous AI agents"
+  />
+  <Card
+    title="API Reference"
+    href="/docs/ai-sdk-v7/transformers-js/api-reference"
+    description="Complete API documentation"
+  />
+</Cards>

--- a/docs/content/docs/ai-sdk-v7/transformers-js/installation.mdx
+++ b/docs/content/docs/ai-sdk-v7/transformers-js/installation.mdx
@@ -1,0 +1,38 @@
+---
+title: Installation
+description: Setup @browser-ai/transformers-js for AI SDK v7
+---
+
+## Package Installation
+
+```bash
+npm i @browser-ai/transformers-js
+```
+
+## Version Compatibility
+
+| @browser-ai/transformers-js | AI SDK | Notes                        |
+| --------------------------- | ------ | ---------------------------- |
+| v3.0.0 and above            | v7.x   | Current stable for AI SDK v7 |
+| v2.x                        | v6.x   | Use for AI SDK v6            |
+| v1.0.0                      | v5.x   | Use for AI SDK v5            |
+
+<Callout type="info">
+  For AI SDK v6, please refer to the [v6
+  documentation](/docs/ai-sdk-v6/transformers-js/installation), and for AI SDK
+  v5 the [v5 documentation](/docs/ai-sdk-v5/transformers-js/installation).
+</Callout>
+
+## Verifying Installation
+
+After installation, you can verify browser support:
+
+```typescript
+import { doesBrowserSupportTransformersJS } from "@browser-ai/transformers-js";
+
+if (doesBrowserSupportTransformersJS()) {
+  console.log("Browser supports Transformers.js with WebGPU!");
+} else {
+  console.log("WebGPU not available, falling back to WASM or server");
+}
+```

--- a/docs/content/docs/ai-sdk-v7/transformers-js/meta.json
+++ b/docs/content/docs/ai-sdk-v7/transformers-js/meta.json
@@ -1,0 +1,14 @@
+{
+  "title": "@browser-ai/transformers-js",
+  "description": "Hugging Face Transformers models in the browser",
+  "icon": "Sparkles",
+  "pages": [
+    "index",
+    "why",
+    "installation",
+    "usage",
+    "usechat-integration",
+    "agents",
+    "api-reference"
+  ]
+}

--- a/docs/content/docs/ai-sdk-v7/transformers-js/usage.mdx
+++ b/docs/content/docs/ai-sdk-v7/transformers-js/usage.mdx
@@ -1,0 +1,238 @@
+---
+title: Usage
+description: Features and usage examples for @browser-ai/transformers-js with AI SDK v7
+---
+
+## Basic Text Generation
+
+### Streaming Text
+
+```typescript
+import { streamText } from "ai";
+import { transformersJS } from "@browser-ai/transformers-js";
+
+const result = streamText({
+  model: transformersJS("HuggingFaceTB/SmolLM2-360M-Instruct"),
+  prompt: "Invent a new holiday and describe its traditions.",
+});
+
+for await (const textPart of result.textStream) {
+  console.log(textPart);
+}
+```
+
+### Non-streaming Text
+
+```typescript
+import { generateText } from "ai";
+import { transformersJS } from "@browser-ai/transformers-js";
+
+const result = await generateText({
+  model: transformersJS("HuggingFaceTB/SmolLM2-360M-Instruct"),
+  prompt: "Invent a new holiday and describe its traditions.",
+});
+
+console.log(result.text);
+```
+
+## Text Embeddings
+
+Generate text embeddings using Transformers.js embedding models:
+
+```typescript
+import { embed, embedMany } from "ai";
+import { transformersJS } from "@browser-ai/transformers-js";
+
+// Single embedding
+const { embedding, usage } = await embed({
+  model: transformersJS.embedding("Supabase/gte-small"),
+  value: "Hello, world!",
+});
+
+// Multiple embeddings
+const { embedding, usage } = await embedMany({
+  model: transformersJS.embedding("Supabase/gte-small"),
+  values: ["Hello", "World", "AI"],
+});
+```
+
+## Download Progress Tracking
+
+When using models for the first time, they need to be downloaded. Track progress to improve UX:
+
+```typescript
+import { streamText } from "ai";
+import { transformersJS } from "@browser-ai/transformers-js";
+
+const model = transformersJS("HuggingFaceTB/SmolLM2-360M-Instruct");
+const availability = await model.availability();
+
+if (availability === "unavailable") {
+  console.log("Browser doesn't support Transformers.js");
+  return;
+}
+
+if (availability === "downloadable") {
+  await model.createSessionWithProgress((progress) => {
+    console.log(`Download progress: ${Math.round(progress * 100)}%`);
+  });
+}
+
+// Model is ready
+const result = streamText({
+  model,
+  prompt: "Invent a new holiday and describe its traditions.",
+});
+```
+
+## Vision Models
+
+Process images with vision-capable models:
+
+```typescript
+import { streamText } from "ai";
+import { transformersJS } from "@browser-ai/transformers-js";
+
+const result = streamText({
+  model: transformersJS("HuggingFaceTB/SmolVLM-256M-Instruct", {
+    isVisionModel: true,
+    device: "webgpu",
+  }),
+  messages: [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "Describe this image" },
+        { type: "file", mediaType: "image/png", data: base64ImageData },
+      ],
+    },
+  ],
+});
+
+for await (const chunk of result.textStream) {
+  console.log(chunk);
+}
+```
+
+## Audio Transcription
+
+Transcribe audio using Whisper models:
+
+```typescript
+import { transcribe } from "ai";
+import { transformersJS } from "@browser-ai/transformers-js";
+
+const transcript = await transcribe({
+  model: transformersJS.transcription("Xenova/whisper-base"),
+  audio: audioFile,
+});
+
+console.log(transcript.text);
+console.log(transcript.segments); // Array of segments with timestamps
+```
+
+## Tool Calling
+
+<Callout type="info">
+  For best tool calling results, use reasoning models like Qwen3.
+</Callout>
+
+The `transformersJS` model supports tool calling with multi-step execution:
+
+```typescript
+import { streamText, tool, isStepCount } from "ai";
+import { transformersJS } from "@browser-ai/transformers-js";
+import { z } from "zod";
+
+const result = await streamText({
+  model: transformersJS("onnx-community/Qwen3-0.6B-ONNX"),
+  messages: [{ role: "user", content: "What's the weather in San Francisco?" }],
+  tools: {
+    weather: tool({
+      description: "Get the weather in a location",
+      inputSchema: z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10,
+      }),
+    }),
+  },
+  stopWhen: isStepCount(5), // multiple steps
+});
+```
+
+It also supports [tool execution approval](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#tool-execution-approval), which in AI SDK v7 is configured with the `toolApproval` option on the call (or agent) instead of `needsApproval` on the tool.
+
+## Tool Calling with Structured Output
+
+Not yet implemented.
+
+## Structured Output
+
+Not yet implemented.
+
+## Web Worker Usage
+
+For better performance, run models off the main thread:
+
+### 1. Create worker.ts
+
+```typescript
+import { TransformersJSWorkerHandler } from "@browser-ai/transformers-js";
+
+const handler = new TransformersJSWorkerHandler();
+self.onmessage = (msg: MessageEvent) => {
+  handler.onmessage(msg);
+};
+```
+
+### 2. Use the worker
+
+```typescript
+import { streamText } from "ai";
+import { transformersJS } from "@browser-ai/transformers-js";
+
+const model = transformersJS("HuggingFaceTB/SmolLM2-360M-Instruct", {
+  worker: new Worker(new URL("./worker.ts", import.meta.url), {
+    type: "module",
+  }),
+  device: "webgpu",
+});
+
+const result = streamText({
+  model,
+  messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+## Server-side Inference
+
+Transformers.js allows running the in-browser models on the server too:
+
+```typescript
+// In a Next.js API route (app/api/chat/route.ts)
+import {
+  streamText,
+  toUIMessageStream,
+  createUIMessageStreamResponse,
+} from "ai";
+import { transformersJS } from "@browser-ai/transformers-js";
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const model = transformersJS("HuggingFaceTB/SmolLM2-135M-Instruct");
+
+  const result = streamText({
+    model,
+    messages,
+    temperature: 0.7,
+  });
+
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
+}
+```

--- a/docs/content/docs/ai-sdk-v7/transformers-js/usechat-integration.mdx
+++ b/docs/content/docs/ai-sdk-v7/transformers-js/usechat-integration.mdx
@@ -1,3 +1,16 @@
+---
+title: useChat Integration
+description: Integrate @browser-ai/transformers-js with the useChat hook in AI SDK v7
+---
+
+## Overview
+
+When using this library with the `useChat` hook, you'll need to create a [custom transport](https://ai-sdk.dev/docs/ai-sdk-ui/transport) implementation to handle client-side AI with download progress.
+This is not required, but it makes it easier for you to build better user experiences.
+
+## Complete Transport Example
+
+```ts
 import {
   ChatTransport,
   UIMessageChunk,
@@ -5,8 +18,6 @@ import {
   convertToModelMessages,
   ChatRequestOptions,
   createUIMessageStream,
-  wrapLanguageModel,
-  extractReasoningMiddleware,
   tool,
   isStepCount,
   toUIMessageStream,
@@ -27,50 +38,7 @@ export const createTools = () => ({
         .describe("The search query to find information on the web"),
     }),
     execute: async ({ query }) => {
-      try {
-        // Call the API route instead of Exa directly
-        const response = await fetch("/api/web-search", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ query }),
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json();
-          return errorData.error || "Failed to search the web";
-        }
-
-        const result = await response.json();
-        return result;
-      } catch (err) {
-        return `Failed to search the web: ${err instanceof Error ? err.message : "Unknown error"}`;
-      }
-    },
-  }),
-  getCurrentTime: tool({
-    description:
-      "Get the current date and time. Use this when the user asks about the current time, date, or day of the week.",
-    inputSchema: z.object({}),
-    execute: async () => {
-      const now = new Date();
-      return {
-        timestamp: now.toISOString(),
-        date: now.toLocaleDateString("en-US", {
-          weekday: "long",
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        }),
-        time: now.toLocaleTimeString("en-US", {
-          hour: "2-digit",
-          minute: "2-digit",
-          second: "2-digit",
-          hour12: true,
-        }),
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      };
+      // ...
     },
   }),
 });
@@ -83,7 +51,6 @@ export const createTools = () => ({
  */
 export class TransformersChatTransport implements ChatTransport<TransformersUIMessage> {
   private readonly model: TransformersJSLanguageModel;
-  public enableThinking = false;
   private tools: ReturnType<typeof createTools>;
 
   constructor(model: TransformersJSLanguageModel) {
@@ -143,30 +110,17 @@ export class TransformersChatTransport implements ChatTransport<TransformersUIMe
                 progress: percent,
                 message: `Downloading browser AI model... ${percent}%`,
               },
-              transient: !downloadProgressId, // transient only on first write
+              transient: !downloadProgressId,
             });
           });
         }
 
         const result = streamText({
-          model: wrapLanguageModel({
-            model,
-            middleware: extractReasoningMiddleware({
-              tagName: "think",
-            }),
-          }),
+          model,
           tools: this.tools,
           stopWhen: isStepCount(5),
-          toolApproval: {
-            webSearch: "user-approval",
-          },
           messages: prompt,
           abortSignal,
-          providerOptions: {
-            "transformers-js": {
-              enableThinking: this.enableThinking,
-            },
-          },
           onChunk: (event) => {
             if (event.chunk.type === "text-delta" && downloadProgressId) {
               writer.write({
@@ -199,3 +153,108 @@ export class TransformersChatTransport implements ChatTransport<TransformersUIMe
     return null;
   }
 }
+```
+
+## Basic Transport Structure
+
+Here's a simplified example of how to structure a custom transport:
+
+```typescript
+import {
+  ChatTransport,
+  UIMessageChunk,
+  streamText,
+  convertToModelMessages,
+  ChatRequestOptions,
+  toUIMessageStream,
+} from "ai";
+import {
+  TransformersJSLanguageModel,
+  TransformersUIMessage,
+} from "@browser-ai/transformers-js";
+
+// This class won't stream back data parts with the download progress if
+// the model hasn't yet been downloaded
+export class SimpleTransformersChatTransport implements ChatTransport<TransformersUIMessage> {
+  private readonly model: TransformersJSLanguageModel;
+
+  constructor(model: TransformersJSLanguageModel) {
+    this.model = model;
+  }
+
+  async sendMessages(
+    options: {
+      chatId: string;
+      messages: TransformersUIMessage[];
+      abortSignal: AbortSignal | undefined;
+    } & {
+      trigger: "submit-message" | "submit-tool-result" | "regenerate-message";
+      messageId: string | undefined;
+    } & ChatRequestOptions,
+  ): Promise<ReadableStream<UIMessageChunk>> {
+    const prompt = convertToModelMessages(options.messages);
+
+    const result = streamText({
+      model: this.model,
+      messages: prompt,
+      abortSignal: options.abortSignal,
+    });
+
+    return toUIMessageStream({ stream: result.stream });
+  }
+
+  async reconnectToStream(
+    options: {
+      chatId: string;
+    } & ChatRequestOptions,
+  ): Promise<ReadableStream<UIMessageChunk> | null> {
+    // Client-side AI doesn't support stream reconnection
+    return null;
+  }
+}
+```
+
+You can then use the `useChat()` hook in your components:
+
+```ts
+import {
+  transformersJS,
+  TransformersUIMessage,
+} from "@browser-ai/transformers-js";
+
+const model = transformersJS("HuggingFaceTB/SmolLM2-360M-Instruct", {
+  device: "webgpu",
+  worker: new Worker(new URL("./worker.ts", import.meta.url), {
+    type: "module",
+  }),
+});
+
+const { sendMessage, messages, stop } = useChat<TransformersUIMessage>({
+  transport: new TransformersChatTransport(model),
+});
+```
+
+In case the device is incompatible with local in-browser LLMs, and we want to use a server-side AI model, we can simply use the utility function from the package first:
+
+```ts
+import {
+  transformersJS,
+  TransformersUIMessage,
+  doesBrowserSupportTransformersJS,
+} from "@browser-ai/transformers-js";
+
+const model = transformersJS("HuggingFaceTB/SmolLM2-360M-Instruct", {
+  device: "webgpu",
+  worker: new Worker(new URL("./worker.ts", import.meta.url), {
+    type: "module",
+  }),
+});
+
+const { sendMessage, messages, stop } = useChat<TransformersUIMessage>({
+  transport: doesBrowserSupportTransformersJS() // check for device compatibility
+    ? new TransformersChatTransport(model)
+    : new DefaultChatTransport<UIMessage>({
+        api: "/api/chat",
+      }),
+});
+```

--- a/docs/content/docs/ai-sdk-v7/transformers-js/why.mdx
+++ b/docs/content/docs/ai-sdk-v7/transformers-js/why.mdx
@@ -1,0 +1,316 @@
+---
+title: Why?
+description: Why use @browser-ai/transformers-js instead of just Transformers.js
+---
+
+## The Problem
+
+Running Hugging Face models in the browser with just `@huggingface/transformers` requires significant boilerplate code. You need to handle:
+
+- Web Worker setup and communication
+- Progress tracking
+- Streaming token generation
+- Interrupt handling
+- Error states
+- State management
+
+## Before: Just Transformers.js
+
+Here's what a typical Web Worker looks like with just `@huggingface/transformers`:
+
+```typescript title="worker.ts"
+import {
+  AutoTokenizer,
+  AutoModelForCausalLM,
+  TextStreamer,
+  InterruptableStoppingCriteria,
+} from "@huggingface/transformers";
+
+async function check() {
+  try {
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter) {
+      throw new Error("WebGPU is not supported (no adapter found)");
+    }
+  } catch (e) {
+    self.postMessage({
+      status: "error",
+      data: e.toString(),
+    });
+  }
+}
+
+class TextGenerationPipeline {
+  static model_id = "HuggingFaceTB/SmolLM2-1.7B-Instruct";
+
+  static async getInstance(progress_callback = null) {
+    this.tokenizer ??= AutoTokenizer.from_pretrained(this.model_id, {
+      progress_callback,
+    });
+
+    this.model ??= AutoModelForCausalLM.from_pretrained(this.model_id, {
+      dtype: "q4f16",
+      device: "webgpu",
+      progress_callback,
+    });
+
+    return Promise.all([this.tokenizer, this.model]);
+  }
+}
+
+const stopping_criteria = new InterruptableStoppingCriteria();
+
+let past_key_values_cache = null;
+async function generate(messages) {
+  const [tokenizer, model] = await TextGenerationPipeline.getInstance();
+
+  const inputs = tokenizer.apply_chat_template(messages, {
+    add_generation_prompt: true,
+    return_dict: true,
+  });
+
+  let startTime;
+  let numTokens = 0;
+  let tps;
+  const token_callback_function = () => {
+    startTime ??= performance.now();
+
+    if (numTokens++ > 0) {
+      tps = (numTokens / (performance.now() - startTime)) * 1000;
+    }
+  };
+  const callback_function = (output) => {
+    self.postMessage({
+      status: "update",
+      output,
+      tps,
+      numTokens,
+    });
+  };
+
+  const streamer = new TextStreamer(tokenizer, {
+    skip_prompt: true,
+    skip_special_tokens: true,
+    callback_function,
+    token_callback_function,
+  });
+
+  self.postMessage({ status: "start" });
+
+  const { past_key_values, sequences } = await model.generate({
+    ...inputs,
+    past_key_values: past_key_values_cache,
+    max_new_tokens: 1024,
+    streamer,
+    stopping_criteria,
+    return_dict_in_generate: true,
+  });
+  past_key_values_cache = past_key_values;
+
+  const decoded = tokenizer.batch_decode(sequences, {
+    skip_special_tokens: true,
+  });
+
+  self.postMessage({
+    status: "complete",
+    output: decoded,
+  });
+}
+
+async function load() {
+  self.postMessage({
+    status: "loading",
+    data: "Loading model...",
+  });
+
+  const [tokenizer, model] = await TextGenerationPipeline.getInstance((x) => {
+    self.postMessage(x);
+  });
+
+  self.postMessage({
+    status: "loading",
+    data: "Compiling shaders and warming up model...",
+  });
+
+  const inputs = tokenizer("a");
+  await model.generate({ ...inputs, max_new_tokens: 1 });
+  self.postMessage({ status: "ready" });
+}
+
+self.addEventListener("message", async (e) => {
+  const { type, data } = e.data;
+
+  switch (type) {
+    case "check":
+      check();
+      break;
+    case "load":
+      load();
+      break;
+    case "generate":
+      stopping_criteria.reset();
+      generate(data);
+      break;
+    case "interrupt":
+      stopping_criteria.interrupt();
+      break;
+    case "reset":
+      past_key_values_cache = null;
+      stopping_criteria.reset();
+      break;
+  }
+});
+```
+
+**That's ~130 lines of complex code** just for the worker. And you still need to write the component code to handle all the message passing, state management, etc.!
+
+## After: With @browser-ai/transformers-js
+
+```typescript title="worker.ts"
+import { TransformersJSWorkerHandler } from "@browser-ai/transformers-js";
+
+const handler = new TransformersJSWorkerHandler();
+self.onmessage = (msg: MessageEvent) => {
+  handler.onmessage(msg);
+};
+```
+
+**6 lines of code.**
+
+---
+
+## Component Code Comparison
+
+### Before: Using just Transformers.js
+
+```typescript title="App.tsx"
+function App() {
+  const worker = useRef(null);
+  const textareaRef = useRef(null);
+  const chatContainerRef = useRef(null);
+
+  const [status, setStatus] = useState(null);
+  const [error, setError] = useState(null);
+  const [loadingMessage, setLoadingMessage] = useState("");
+  const [progressItems, setProgressItems] = useState([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState([]);
+  const [tps, setTps] = useState(null);
+  const [numTokens, setNumTokens] = useState(null);
+
+  function onEnter(message) {
+    setMessages((prev) => [...prev, { role: "user", content: message }]);
+    setTps(null);
+    setIsRunning(true);
+    setInput("");
+  }
+
+  function onInterrupt() {
+    worker.current.postMessage({ type: "interrupt" });
+  }
+
+  useEffect(() => {
+    if (!worker.current) {
+      worker.current = new Worker(new URL("./worker.js", import.meta.url), {
+        type: "module",
+      });
+      worker.current.postMessage({ type: "check" });
+    }
+
+    const onMessageReceived = (e) => {
+      switch (e.data.status) {
+        case "loading":
+          setStatus("loading");
+          setLoadingMessage(e.data.data);
+          break;
+        case "initiate":
+          setProgressItems((prev) => [...prev, e.data]);
+          break;
+        case "progress":
+          setProgressItems((prev) =>
+            prev.map((item) => {
+              if (item.file === e.data.file) {
+                return { ...item, ...e.data };
+              }
+              return item;
+            }),
+          );
+          break;
+        case "done":
+          setProgressItems((prev) =>
+            prev.filter((item) => item.file !== e.data.file),
+          );
+          break;
+        case "ready":
+          setStatus("ready");
+          break;
+        case "start":
+          setMessages((prev) => [...prev, { role: "assistant", content: "" }]);
+          break;
+        case "update":
+          const { output, tps, numTokens } = e.data;
+          setTps(tps);
+          setNumTokens(numTokens);
+          setMessages((prev) => {
+            const cloned = [...prev];
+            const last = cloned.at(-1);
+            cloned[cloned.length - 1] = {
+              ...last,
+              content: last.content + output,
+            };
+            return cloned;
+          });
+          break;
+        case "complete":
+          setIsRunning(false);
+          break;
+        case "error":
+          setError(e.data.data);
+          break;
+      }
+    };
+
+    worker.current.addEventListener("message", onMessageReceived);
+    worker.current.addEventListener("error", onErrorReceived);
+
+    return () => {
+      worker.current.removeEventListener("message", onMessageReceived);
+      worker.current.removeEventListener("error", onErrorReceived);
+    };
+  }, []);
+
+  // ... rest of the component
+}
+```
+
+**~100+ lines** of state management and event handling.
+
+### After: With @browser-ai/transformers-js
+
+```typescript title="App.tsx"
+import { useChat } from "ai/react";
+import {
+  transformersJS,
+  TransformersUIMessage,
+} from "@browser-ai/transformers-js";
+
+const model = transformersJS("HuggingFaceTB/SmolLM2-360M-Instruct", {
+  device: "webgpu",
+  dtype: "q4",
+  worker: new Worker(new URL("./worker.ts", import.meta.url), {
+    type: "module",
+  }),
+});
+
+function App() {
+  const { error, status, sendMessage, messages, stop } =
+    useChat<TransformersUIMessage>({
+      transport: new TransformersChatTransport(model),
+    });
+
+  // ... your UI
+}
+```
+
+**Just a few lines.** Declarative. All the complexity is abstracted away, giving you control over the UX instead.

--- a/docs/content/docs/ai-sdk-v7/web-llm/agents.mdx
+++ b/docs/content/docs/ai-sdk-v7/web-llm/agents.mdx
@@ -1,0 +1,57 @@
+---
+title: Agents
+description: Build autonomous AI agents with @browser-ai/web-llm and AI SDK v7
+---
+
+## Basic Agent Example
+
+Create an agent that can search the web and analyze content:
+
+```typescript
+import { ToolLoopAgent, isStepCount, tool } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+import { z } from "zod";
+
+const weatherAgent = new ToolLoopAgent({
+  model: webLLM("Qwen3-1.7B-q4f16_1-MLC"),
+  instructions: "You are a weather assistant.",
+  tools: {
+    weather: tool({
+      description: "Get the weather in a location (in Fahrenheit)",
+      inputSchema: z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10,
+      }),
+    }),
+    convertFahrenheitToCelsius: tool({
+      description: "Convert temperature from Fahrenheit to Celsius",
+      inputSchema: z.object({
+        temperature: z.number().describe("Temperature in Fahrenheit"),
+      }),
+      execute: async ({ temperature }) => {
+        const celsius = Math.round((temperature - 32) * (5 / 9));
+        return { celsius };
+      },
+    }),
+  },
+  // Agent's default behavior is to stop after a maximum of 20 steps
+  // stopWhen: isStepCount(20),
+});
+
+const result = await weatherAgent.generate({
+  prompt: "What is the weather in San Francisco in celsius?",
+});
+
+console.log(result.text); // agent's final answer
+console.log(result.steps); // steps taken by the agent
+```
+
+<Callout type="info">
+  For best agent results, use reasoning models like Qwen3 which handle
+  multi-step reasoning better.
+</Callout>
+
+Check the [Vercel documentation](https://ai-sdk.dev/docs/agents/overview) for more information.

--- a/docs/content/docs/ai-sdk-v7/web-llm/api-reference.mdx
+++ b/docs/content/docs/ai-sdk-v7/web-llm/api-reference.mdx
@@ -1,0 +1,159 @@
+---
+title: API Reference
+description: Complete API documentation for @browser-ai/web-llm with AI SDK v7
+---
+
+## Provider Functions
+
+### `webLLM(modelId, settings?)`
+
+Creates a WebLLM model instance.
+
+**Parameters:**
+
+- `modelId`: The model identifier from the [supported list of models](https://github.com/mlc-ai/web-llm/blob/main/src/config.ts)
+- `settings` (optional): Configuration options
+  - `appConfig?: AppConfig` - Custom app configuration for WebLLM
+  - `initProgressCallback?: (progress: number) => void` - Progress callback for model initialization
+  - `engineConfig?: MLCEngineConfig` - Engine configuration options
+  - `worker?: Worker` - A web worker instance to run the model in for better performance
+
+**Returns:** `WebLLMLanguageModel`
+
+### `webLLM.embeddingModel(modelId, settings?)`
+
+Creates a WebLLM embedding model instance.
+
+**Parameters:**
+
+- `modelId`: The embedding model identifier
+- `settings` (optional): Configuration options
+  - `appConfig?: AppConfig` - Custom app configuration for WebLLM
+  - `initProgressCallback?: (progress: WebLLMProgress) => void` - Progress callback for model initialization
+  - `engineConfig?: MLCEngineConfig` - Engine configuration options
+  - `worker?: Worker` - A web worker instance to run the model in
+  - `maxEmbeddingsPerCall?: number` - Maximum texts per call (default: 100)
+
+**Returns:** `WebLLMEmbeddingModel`
+
+**Available Models:**
+
+| Model ID                                 | Size   | Batch |
+| ---------------------------------------- | ------ | ----- |
+| `snowflake-arctic-embed-m-q0f32-MLC-b32` | Medium | 32    |
+| `snowflake-arctic-embed-m-q0f32-MLC-b4`  | Medium | 4     |
+| `snowflake-arctic-embed-s-q0f32-MLC-b32` | Small  | 32    |
+| `snowflake-arctic-embed-s-q0f32-MLC-b4`  | Small  | 4     |
+
+See [WebLLM config](https://github.com/mlc-ai/web-llm/blob/main/src/config.ts) for the latest list of supported models.
+
+---
+
+## Utility Functions
+
+### `doesBrowserSupportWebLLM()`
+
+Quick check if the browser supports WebLLM. Useful for component-level decisions and feature flags.
+
+**Returns:** `boolean` - `true` if browser supports WebGPU, `false` otherwise
+
+---
+
+## Model Methods
+
+### `WebLLMLanguageModel.availability()`
+
+Checks the current availability status of the WebLLM model.
+
+**Returns:** `Promise<"unavailable" | "downloadable" | "available">`
+
+| Status           | Description                                         |
+| ---------------- | --------------------------------------------------- |
+| `"unavailable"`  | Model is not supported in the browser (no WebGPU)   |
+| `"downloadable"` | Model is supported but needs to be downloaded first |
+| `"available"`    | Model is ready to use                               |
+
+### `WebLLMLanguageModel.createSessionWithProgress(onProgress?)`
+
+Creates a language model session with optional download progress monitoring.
+
+**Parameters:**
+
+- `onProgress?: (progress: number) => void` - Optional callback that receives progress values from 0 to 1 during model download
+
+**Returns:** `Promise<WebLLMLanguageModel>` - The configured language model instance
+
+### `WebLLMLanguageModel.isModelInitialized`
+
+Property that indicates if the model is initialized and ready to use.
+
+**Returns:** `boolean`
+
+---
+
+## Worker Handler
+
+### `WebWorkerMLCEngineHandler`
+
+Re-exported from `@mlc-ai/web-llm` for Web Worker usage.
+
+```typescript
+import { WebWorkerMLCEngineHandler } from "@browser-ai/web-llm";
+
+const handler = new WebWorkerMLCEngineHandler();
+self.onmessage = (msg: MessageEvent) => handler.onmessage(msg);
+```
+
+---
+
+## Types
+
+### `WebLLMUIMessage`
+
+Extended UI message type for use with the `useChat` hook that includes custom data parts for WebLLM functionality.
+
+```typescript
+type WebLLMUIMessage = UIMessage<
+  never,
+  {
+    modelDownloadProgress: {
+      status: "downloading" | "complete" | "error";
+      progress?: number;
+      message: string;
+    };
+    notification: {
+      message: string;
+      level: "info" | "warning" | "error";
+    };
+  }
+>;
+```
+
+### `DownloadProgressCallback`
+
+The callback type for receiving model download progress. Shared across all `@browser-ai` packages.
+
+```typescript
+type DownloadProgressCallback = (progress: number) => void;
+```
+
+### `WebLLMModelId`
+
+Type alias for model identifiers.
+
+```typescript
+type WebLLMModelId = string;
+```
+
+### `WebLLMSettings`
+
+Configuration options for the WebLLM model.
+
+```typescript
+interface WebLLMSettings {
+  appConfig?: AppConfig;
+  initProgressCallback?: (progress: number) => void;
+  engineConfig?: MLCEngineConfig;
+  worker?: Worker;
+}
+```

--- a/docs/content/docs/ai-sdk-v7/web-llm/index.mdx
+++ b/docs/content/docs/ai-sdk-v7/web-llm/index.mdx
@@ -1,0 +1,44 @@
+---
+title: "Overview"
+description: WebLLM model provider for Vercel AI SDK v7
+---
+
+The `@browser-ai/web-llm` package enables you to run [WebLLM](https://github.com/mlc-ai/web-llm) compiled models directly in the browser with seamless integration with the Vercel AI SDK v7.
+
+### What's Included
+
+- **Language Models**: Text generation with Llama, Qwen, Phi, and more
+- **Tool Calling**: Function calling with JSON format support
+- **Structured Output**: Generate validated JSON objects
+- **Agents**: Multi-step autonomous workflows
+- **Web Worker Support**: Off-main-thread execution for better UX
+
+## Quick Links
+
+<Cards>
+  <Card
+    title="Installation"
+    href="/docs/ai-sdk-v7/web-llm/installation"
+    description="Setup and browser requirements"
+  />
+  <Card
+    title="Usage"
+    href="/docs/ai-sdk-v7/web-llm/usage"
+    description="Features and usage examples"
+  />
+  <Card
+    title="useChat Integration"
+    href="/docs/ai-sdk-v7/web-llm/usechat-integration"
+    description="React hook integration"
+  />
+  <Card
+    title="Agents"
+    href="/docs/ai-sdk-v7/web-llm/agents"
+    description="Build autonomous AI agents"
+  />
+  <Card
+    title="API Reference"
+    href="/docs/ai-sdk-v7/web-llm/api-reference"
+    description="Complete API documentation"
+  />
+</Cards>

--- a/docs/content/docs/ai-sdk-v7/web-llm/installation.mdx
+++ b/docs/content/docs/ai-sdk-v7/web-llm/installation.mdx
@@ -1,0 +1,38 @@
+---
+title: Installation
+description: Setup @browser-ai/web-llm for AI SDK v7
+---
+
+## Package Installation
+
+```bash
+npm i @browser-ai/web-llm
+```
+
+## Version Compatibility
+
+| @browser-ai/web-llm | AI SDK | Notes                        |
+| ------------------- | ------ | ---------------------------- |
+| v3.0.0 and above    | v7.x   | Current stable for AI SDK v7 |
+| v2.x                | v6.x   | Use for AI SDK v6            |
+| v1.0.0 and below    | v5.x   | Use for AI SDK v5            |
+
+<Callout type="info">
+  For AI SDK v6, please refer to the [v6
+  documentation](/docs/ai-sdk-v6/web-llm/installation), and for AI SDK v5 the
+  [v5 documentation](/docs/ai-sdk-v5/web-llm/installation).
+</Callout>
+
+## Verifying Installation
+
+After installation, you can verify browser support:
+
+```typescript
+import { doesBrowserSupportWebLLM } from "@browser-ai/web-llm";
+
+if (doesBrowserSupportWebLLM()) {
+  console.log("Browser supports WebLLM!");
+} else {
+  console.log("WebLLM not available, use server fallback");
+}
+```

--- a/docs/content/docs/ai-sdk-v7/web-llm/meta.json
+++ b/docs/content/docs/ai-sdk-v7/web-llm/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "@browser-ai/web-llm",
+  "description": "WebLLM models in the browser",
+  "icon": "Zap",
+  "pages": [
+    "index",
+    "installation",
+    "usage",
+    "usechat-integration",
+    "agents",
+    "api-reference"
+  ]
+}

--- a/docs/content/docs/ai-sdk-v7/web-llm/usage.mdx
+++ b/docs/content/docs/ai-sdk-v7/web-llm/usage.mdx
@@ -1,0 +1,295 @@
+---
+title: Usage
+description: Features and usage examples for @browser-ai/web-llm with AI SDK v7
+---
+
+## Basic Text Generation
+
+### Streaming Text
+
+```typescript
+import { streamText } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+
+const result = streamText({
+  model: webLLM("Qwen3-0.6B-q0f16-MLC"),
+  prompt: "Invent a new holiday and describe its traditions.",
+});
+
+for await (const textPart of result.textStream) {
+  console.log(textPart);
+}
+```
+
+### Non-streaming Text
+
+```typescript
+import { generateText } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+
+const result = await generateText({
+  model: webLLM("Qwen3-0.6B-q0f16-MLC"),
+  prompt: "Invent a new holiday and describe its traditions.",
+});
+
+console.log(result.text);
+```
+
+## Download Progress Tracking
+
+When using WebLLM models for the first time, the model needs to be downloaded. Track progress to improve UX:
+
+```typescript
+import { streamText } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+
+const model = webLLM("Qwen3-0.6B-q0f16-MLC");
+const availability = await model.availability();
+
+if (availability === "unavailable") {
+  console.log("Browser doesn't support WebLLM");
+  return;
+}
+
+if (availability === "downloadable") {
+  await model.createSessionWithProgress((progress) => {
+    console.log(`Download progress: ${Math.round(progress * 100)}%`);
+  });
+}
+
+// Model is ready
+const result = streamText({
+  model,
+  messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+## Tool Calling
+
+<Callout type="info">
+  For best tool calling results, use reasoning models like Qwen3.
+</Callout>
+
+The `webLLM` model supports tool calling with multi-step execution:
+
+```typescript
+import { streamText, tool, isStepCount } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+import { z } from "zod";
+
+const result = await streamText({
+  model: webLLM("Qwen3-0.6B-q0f16-MLC"),
+  messages: [{ role: "user", content: "What's the weather in San Francisco?" }],
+  tools: {
+    weather: tool({
+      description: "Get the weather in a location",
+      inputSchema: z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10,
+      }),
+    }),
+  },
+  stopWhen: isStepCount(5), // multiple steps
+});
+```
+
+It also supports [tool execution approval](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#tool-execution-approval), which in AI SDK v7 is configured with the `toolApproval` option on the call (or agent) instead of `needsApproval` on the tool.
+
+## Tool Calling with Structured Output
+
+```ts
+import { Output, ToolLoopAgent, tool } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+import { z } from "zod";
+
+const agent = new ToolLoopAgent({
+  model: webLLM("Qwen3-0.6B-q0f16-MLC"),
+  tools: {
+    weather: tool({
+      description: "Get the weather in a location",
+      inputSchema: z.object({ city: z.string() }),
+      execute: async ({ city }) => {
+        // ...
+      },
+    }),
+  },
+  output: Output.object({
+    schema: z.object({
+      summary: z.string(),
+      temperature: z.number(),
+      recommendation: z.string(),
+    }),
+  }),
+});
+
+const { output } = await agent.generate({
+  prompt: "What is the weather in San Francisco and what should I wear?",
+});
+```
+
+## Structured Output
+
+Generate structured JSON output with schema validation:
+
+### Using generateText
+
+```typescript
+import { generateText, Output } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+import { z } from "zod";
+
+const { output } = await generateText({
+  model: webLLM("Qwen3-0.6B-q0f16-MLC"),
+  output: Output.object({
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({ name: z.string(), amount: z.string() }),
+        ),
+        steps: z.array(z.string()),
+      }),
+    }),
+  }),
+  prompt: "Generate a lasagna recipe.",
+});
+```
+
+### Using streamText
+
+```typescript
+import { streamText, Output } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+import { z } from "zod";
+
+const { partialOutputStream } = streamText({
+  model: webLLM("Qwen3-0.6B-q0f16-MLC"),
+  output: Output.object({
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({ name: z.string(), amount: z.string() }),
+        ),
+        steps: z.array(z.string()),
+      }),
+    }),
+  }),
+  prompt: "Generate a lasagna recipe.",
+});
+```
+
+## Web Worker Usage
+
+For better performance, run models off the main thread:
+
+### 1. Create worker.ts
+
+```typescript
+import { WebWorkerMLCEngineHandler } from "@browser-ai/web-llm";
+
+const handler = new WebWorkerMLCEngineHandler();
+self.onmessage = (msg: MessageEvent) => {
+  handler.onmessage(msg);
+};
+```
+
+### 2. Use the worker
+
+```typescript
+import { streamText } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+
+const model = webLLM("Qwen3-0.6B-q0f16-MLC", {
+  worker: new Worker(new URL("./worker.ts", import.meta.url), {
+    type: "module",
+  }),
+});
+
+const result = streamText({
+  model,
+  messages: [{ role: "user", content: "Hello!" }],
+});
+
+for await (const chunk of result.textStream) {
+  console.log(chunk);
+}
+```
+
+## Embeddings
+
+Generate text embeddings for semantic search, RAG, and similarity matching.
+
+**Available models:** `snowflake-arctic-embed-m-q0f32-MLC-b32`, `snowflake-arctic-embed-s-q0f32-MLC-b32`, and variants. See [WebLLM config](https://github.com/mlc-ai/web-llm/blob/main/src/config.ts) for the full list.
+
+### Basic Embedding
+
+```typescript
+import { embed } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+
+const model = webLLM.embeddingModel("snowflake-arctic-embed-m-q0f32-MLC-b32");
+
+const { embedding } = await embed({
+  model,
+  value: "What is the meaning of life?",
+});
+
+console.log(embedding); // [0.123, -0.456, ...]
+```
+
+### Multiple Embeddings
+
+```typescript
+import { embedMany } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+
+const model = webLLM.embeddingModel("snowflake-arctic-embed-m-q0f32-MLC-b32");
+
+const { embeddings } = await embedMany({
+  model,
+  values: ["first document", "second document", "third document"],
+});
+```
+
+### Similarity Search
+
+```typescript
+import { embed, cosineSimilarity } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+
+const model = webLLM.embeddingModel("snowflake-arctic-embed-m-q0f32-MLC-b32");
+
+const { embedding: queryEmbedding } = await embed({
+  model,
+  value: "What is AI?",
+});
+
+const { embedding: docEmbedding } = await embed({
+  model,
+  value: "Artificial intelligence is a branch of computer science.",
+});
+
+const similarity = cosineSimilarity(queryEmbedding, docEmbedding);
+console.log(similarity); // 0.87
+```
+
+### Download Progress Tracking
+
+```typescript
+import { embed } from "ai";
+import { webLLM } from "@browser-ai/web-llm";
+
+const model = webLLM.embeddingModel("snowflake-arctic-embed-m-q0f32-MLC-b32");
+
+if ((await model.availability()) === "downloadable") {
+  await model.createSessionWithProgress((progress) => {
+    console.log(`Download: ${progress.text}`);
+  });
+}
+
+const { embedding } = await embed({ model, value: "hello" });
+```

--- a/docs/content/docs/ai-sdk-v7/web-llm/usechat-integration.mdx
+++ b/docs/content/docs/ai-sdk-v7/web-llm/usechat-integration.mdx
@@ -1,3 +1,16 @@
+---
+title: useChat Integration
+description: Integrate @browser-ai/web-llm with the useChat hook in AI SDK v7
+---
+
+## Overview
+
+When using this library with the `useChat` hook, you'll need to create a [custom transport](https://ai-sdk.dev/docs/ai-sdk-ui/transport) implementation to handle client-side AI with download progress.
+This is not required, but it makes it easier for you to build better user experiences.
+
+## Complete Transport Example
+
+```ts
 import {
   ChatTransport,
   UIMessageChunk,
@@ -5,8 +18,6 @@ import {
   convertToModelMessages,
   ChatRequestOptions,
   createUIMessageStream,
-  wrapLanguageModel,
-  extractReasoningMiddleware,
   tool,
   isStepCount,
   toUIMessageStream,
@@ -24,50 +35,7 @@ export const createTools = () => ({
         .describe("The search query to find information on the web"),
     }),
     execute: async ({ query }) => {
-      try {
-        // Call the API route instead of Exa directly
-        const response = await fetch("/api/web-search", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ query }),
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json();
-          return errorData.error || "Failed to search the web";
-        }
-
-        const result = await response.json();
-        return result;
-      } catch (err) {
-        return `Failed to search the web: ${err instanceof Error ? err.message : "Unknown error"}`;
-      }
-    },
-  }),
-  getCurrentTime: tool({
-    description:
-      "Get the current date and time. Use this when the user asks about the current time, date, or day of the week.",
-    inputSchema: z.object({}),
-    execute: async () => {
-      const now = new Date();
-      return {
-        timestamp: now.toISOString(),
-        date: now.toLocaleDateString("en-US", {
-          weekday: "long",
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        }),
-        time: now.toLocaleTimeString("en-US", {
-          hour: "2-digit",
-          minute: "2-digit",
-          second: "2-digit",
-          hour12: true,
-        }),
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      };
+      // ...
     },
   }),
 });
@@ -139,23 +107,15 @@ export class WebLLMChatTransport implements ChatTransport<WebLLMUIMessage> {
                 progress: percent,
                 message: `Downloading browser AI model... ${percent}%`,
               },
-              transient: !downloadProgressId, // transient only on first write
+              transient: !downloadProgressId,
             });
           });
         }
 
         const result = streamText({
-          model: wrapLanguageModel({
-            model,
-            middleware: extractReasoningMiddleware({
-              tagName: "think",
-            }),
-          }),
+          model,
           tools: this.tools,
           stopWhen: isStepCount(5),
-          toolApproval: {
-            webSearch: "user-approval",
-          },
           messages: prompt,
           abortSignal,
           onChunk: (event) => {
@@ -190,3 +150,100 @@ export class WebLLMChatTransport implements ChatTransport<WebLLMUIMessage> {
     return null;
   }
 }
+```
+
+## Basic Transport Structure
+
+Here's a simplified example of how to structure a custom transport:
+
+```typescript
+import {
+  ChatTransport,
+  UIMessageChunk,
+  streamText,
+  convertToModelMessages,
+  ChatRequestOptions,
+  toUIMessageStream,
+} from "ai";
+import { WebLLMLanguageModel, WebLLMUIMessage } from "@browser-ai/web-llm";
+
+// This class won't stream back data parts with the download progress if
+// the model hasn't yet been downloaded
+export class SimpleWebLLMChatTransport implements ChatTransport<WebLLMUIMessage> {
+  private readonly model: WebLLMLanguageModel;
+
+  constructor(model: WebLLMLanguageModel) {
+    this.model = model;
+  }
+
+  async sendMessages(
+    options: {
+      chatId: string;
+      messages: WebLLMUIMessage[];
+      abortSignal: AbortSignal | undefined;
+    } & {
+      trigger: "submit-message" | "submit-tool-result" | "regenerate-message";
+      messageId: string | undefined;
+    } & ChatRequestOptions,
+  ): Promise<ReadableStream<UIMessageChunk>> {
+    const prompt = convertToModelMessages(options.messages);
+
+    const result = streamText({
+      model: this.model,
+      messages: prompt,
+      abortSignal: options.abortSignal,
+    });
+
+    return toUIMessageStream({ stream: result.stream });
+  }
+
+  async reconnectToStream(
+    options: {
+      chatId: string;
+    } & ChatRequestOptions,
+  ): Promise<ReadableStream<UIMessageChunk> | null> {
+    // Client-side AI doesn't support stream reconnection
+    return null;
+  }
+}
+```
+
+You can then use the `useChat()` hook in your components:
+
+```ts
+import { webLLM, WebLLMUIMessage } from "@browser-ai/web-llm";
+
+const model = webLLM("Qwen3-0.6B-q0f16-MLC", {
+  worker: new Worker(new URL("./worker.ts", import.meta.url), {
+    type: "module",
+  }),
+});
+
+const { sendMessage, messages, stop } = useChat<WebLLMUIMessage>({
+  transport: new WebLLMChatTransport(model),
+});
+```
+
+In case the device is incompatible with local in-browser LLMs, and we want to use a server-side AI model, we can simply use the utility function from the package first:
+
+```ts
+import {
+  webLLM,
+  WebLLMUIMessage,
+  doesBrowserSupportWebLLM,
+} from "@browser-ai/web-llm";
+
+const model = webLLM("Qwen3-0.6B-q0f16-MLC", {
+  worker: new Worker(new URL("./worker.ts", import.meta.url), {
+    type: "module",
+  }),
+});
+
+const { sendMessage, messages, stop } = useChat<WebLLMUIMessage>({
+  transport: doesBrowserSupportWebLLM() // check for device compatibility
+    ? new WebLLMChatTransport(model)
+    : new DefaultChatTransport<UIMessage>({
+        api: "/api/chat",
+      }),
+});
+```

--- a/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/docs/src/app/docs/[[...slug]]/page.tsx
@@ -13,9 +13,9 @@ import type { Metadata } from "next";
 export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
   const params = await props.params;
 
-  // Redirect /docs to /docs/ai-sdk-v6
+  // Redirect /docs to /docs/ai-sdk-v7
   if (!params.slug || params.slug.length === 0) {
-    redirect("/docs/ai-sdk-v6");
+    redirect("/docs/ai-sdk-v7");
   }
 
   const page = source.getPage(params.slug);

--- a/examples/next-hybrid/app/(core)/util/client-side-chat-transport-simple.ts
+++ b/examples/next-hybrid/app/(core)/util/client-side-chat-transport-simple.ts
@@ -5,6 +5,7 @@ import {
   streamText,
   convertToModelMessages,
   ChatRequestOptions,
+  toUIMessageStream,
 } from "ai";
 import { browserAI } from "@browser-ai/core";
 
@@ -29,7 +30,7 @@ export class SimpleClientSideChatTransport implements ChatTransport<UIMessage> {
       abortSignal: options.abortSignal,
     });
 
-    return result.toUIMessageStream();
+    return toUIMessageStream({ stream: result.stream });
   }
 
   async reconnectToStream(

--- a/examples/next-hybrid/app/(core)/util/client-side-chat-transport.ts
+++ b/examples/next-hybrid/app/(core)/util/client-side-chat-transport.ts
@@ -6,7 +6,8 @@ import {
   ChatRequestOptions,
   createUIMessageStream,
   tool,
-  stepCountIs,
+  isStepCount,
+  toUIMessageStream,
 } from "ai";
 import {
   browserAI,
@@ -24,7 +25,6 @@ export const createTools = () => ({
         .string()
         .describe("The search query to find information on the web"),
     }),
-    needsApproval: true,
     execute: async ({ query }) => {
       try {
         // Call the API route instead of Exa directly
@@ -189,7 +189,11 @@ export class ClientSideChatTransport implements ChatTransport<BrowserAIUIMessage
         const result = streamText({
           model: this.model,
           tools: this.tools,
-          stopWhen: stepCountIs(5),
+          instructions: "You are a helpful assistant running fully in the browser. Keep answers concise.",
+          stopWhen: isStepCount(5),
+          toolApproval: {
+            webSearch: "user-approval",
+          },
           messages: prompt,
           abortSignal,
           onChunk: (event) => {
@@ -202,9 +206,22 @@ export class ClientSideChatTransport implements ChatTransport<BrowserAIUIMessage
               downloadProgressId = undefined;
             }
           },
+          onEnd: ({ usage, finalStep }) => {
+            console.log(
+              `[browser-ai] total usage (all steps): ${usage.totalTokens} tokens, ` +
+                `final step: ${finalStep.usage.totalTokens} tokens, ` +
+                `finish reason: ${finalStep.finishReason}`,
+            );
+          },
         });
 
-        writer.merge(result.toUIMessageStream({ sendStart: false }));
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            tools: this.tools,
+            sendStart: false,
+          }),
+        );
       },
     });
   }

--- a/examples/next-hybrid/app/(core)/util/client-side-chat-transport.ts
+++ b/examples/next-hybrid/app/(core)/util/client-side-chat-transport.ts
@@ -189,7 +189,8 @@ export class ClientSideChatTransport implements ChatTransport<BrowserAIUIMessage
         const result = streamText({
           model: this.model,
           tools: this.tools,
-          instructions: "You are a helpful assistant running fully in the browser. Keep answers concise.",
+          instructions:
+            "You are a helpful assistant running fully in the browser. Keep answers concise.",
           stopWhen: isStepCount(5),
           toolApproval: {
             webSearch: "user-approval",

--- a/examples/next-hybrid/app/api/chat/route.ts
+++ b/examples/next-hybrid/app/api/chat/route.ts
@@ -1,5 +1,11 @@
 import { openai } from "@ai-sdk/openai";
-import { convertToModelMessages, streamText, UIMessage } from "ai";
+import {
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  streamText,
+  toUIMessageStream,
+  UIMessage,
+} from "ai";
 import z from "zod";
 
 export const maxDuration = 30;
@@ -29,5 +35,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
 }

--- a/examples/next-hybrid/app/transformers-js/util/simple-transformers-chat-transport.ts
+++ b/examples/next-hybrid/app/transformers-js/util/simple-transformers-chat-transport.ts
@@ -4,6 +4,7 @@ import {
   streamText,
   convertToModelMessages,
   ChatRequestOptions,
+  toUIMessageStream,
 } from "ai";
 import {
   TransformersJSLanguageModel,
@@ -38,7 +39,7 @@ export class SimpleTransformersChatTransport implements ChatTransport<Transforme
       messages: prompt,
       abortSignal: abortSignal,
     });
-    return result.toUIMessageStream();
+    return toUIMessageStream({ stream: result.stream });
   }
 
   async reconnectToStream(

--- a/examples/next-hybrid/components/ai-elements/context.tsx
+++ b/examples/next-hybrid/components/ai-elements/context.tsx
@@ -318,7 +318,7 @@ export const ContextReasoningUsage = ({
   ...props
 }: ContextReasoningUsageProps) => {
   const { usage, modelId } = useContextValue();
-  const reasoningTokens = usage?.reasoningTokens ?? 0;
+  const reasoningTokens = usage?.outputTokenDetails?.reasoningTokens ?? 0;
 
   if (children) {
     return children;
@@ -358,7 +358,7 @@ export const ContextCacheUsage = ({
   ...props
 }: ContextCacheUsageProps) => {
   const { usage, modelId } = useContextValue();
-  const cacheTokens = usage?.cachedInputTokens ?? 0;
+  const cacheTokens = usage?.inputTokenDetails?.cacheReadTokens ?? 0;
 
   if (children) {
     return children;

--- a/examples/next-hybrid/package.json
+++ b/examples/next-hybrid/package.json
@@ -10,8 +10,8 @@
     "clean": "rm -rf .next"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^3.0.0",
-    "@ai-sdk/react": "^3.0.1",
+    "@ai-sdk/openai": "^4.0.11",
+    "@ai-sdk/react": "^4.0.23",
     "@browser-ai/core": "*",
     "@browser-ai/transformers-js": "*",
     "@browser-ai/web-llm": "*",
@@ -31,7 +31,7 @@
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@shikijs/transformers": "^3.8.0",
     "@vercel/blob": "^2.4.0",
-    "ai": "^6.0.92",
+    "ai": "^7.0.22",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,8 +78,8 @@
       "name": "@example/next-hybrid",
       "version": "0.0.0",
       "dependencies": {
-        "@ai-sdk/openai": "^3.0.0",
-        "@ai-sdk/react": "^3.0.1",
+        "@ai-sdk/openai": "^4.0.11",
+        "@ai-sdk/react": "^4.0.23",
         "@browser-ai/core": "*",
         "@browser-ai/transformers-js": "*",
         "@browser-ai/web-llm": "*",
@@ -99,7 +99,7 @@
         "@radix-ui/react-use-controllable-state": "^1.2.2",
         "@shikijs/transformers": "^3.8.0",
         "@vercel/blob": "^2.4.0",
-        "ai": "^6.0.92",
+        "ai": "^7.0.22",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "embla-carousel-react": "^8.6.0",
@@ -141,18 +141,6 @@
         "typescript": "5.8.3"
       }
     },
-    "examples/next-hybrid/node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/next-hybrid/node_modules/@types/node": {
       "version": "20.17.24",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
@@ -190,58 +178,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "examples/next-hybrid/node_modules/ai": {
-      "version": "6.0.93",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.93.tgz",
-      "integrity": "sha512-txpGaxP2Ty6vzpysy+9l42VkGOokMNb6msLSbeLiyCcstuSWQoeMO7khxY48BAPEfwYsvzxdJ/qX52Q6auH6KA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "3.0.51",
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15",
-        "@opentelemetry/api": "1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "examples/next-hybrid/node_modules/ai/node_modules/@ai-sdk/gateway": {
-      "version": "3.0.51",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.51.tgz",
-      "integrity": "sha512-VXYxgDv2U1GJj6xY3aVd9glEmotGmsQllmKDUEghoghlZhEX6F64JsBQx/TukmlJGM98iAYCmofIwGFddv8ZTA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15",
-        "@vercel/oidc": "3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "examples/next-hybrid/node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
-      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "examples/next-hybrid/node_modules/eslint": {
@@ -397,80 +333,100 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.22.tgz",
-      "integrity": "sha512-NgnlY73JNuooACHqUIz5uMOEWvqR1MMVbb2soGLMozLY1fgwEIF5iJFDAGa5/YArlzw2ATVU7zQu7HkR/FUjgA==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.16.tgz",
+      "integrity": "sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.5",
-        "@ai-sdk/provider-utils": "4.0.9",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.10.tgz",
+      "integrity": "sha512-LP47CEk3e6BwCqXamvv4nKbgOWQ5z5T/qS/J2fola5h98KTy7JT7I1yw5LKtB89MZBLviYmEh98Ep4ovHOz/vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7",
+        "pkce-challenge": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.18.tgz",
-      "integrity": "sha512-uYscTyoaWij9FoPpKRNK8YgtDEuPpQlqREYylJCA8o5YQVQXghV0Dwgk1ehPVpg6USIO4L0C8GqQJ4AMm/Xb1g==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.11.tgz",
+      "integrity": "sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.5",
-        "@ai-sdk/provider-utils": "4.0.9"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.5.tgz",
-      "integrity": "sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.9.tgz",
-      "integrity": "sha512-bB4r6nfhBOpmoS9mePxjRoCy+LnzP3AfhyMGCkGL4Mn9clVNlqEeKj26zEKEtB6yoSVcT1IQ0Zh9fytwMCDnow==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.7.tgz",
+      "integrity": "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.5",
+        "@ai-sdk/provider": "4.0.3",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "3.0.50",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.50.tgz",
-      "integrity": "sha512-oNb368W0Xmb9VJznIR30I3fq97Q5lYC3tMX6M9qim7d7rWtgadXGlZwUbkZfLwXdeoP5snr5to/3AwoWh2m+/g==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.23.tgz",
+      "integrity": "sha512-nJ96yQE1013tafK9Pec3uSGTScXg8dc3t4xyydm+a0AfkaSewR58+Eg3l+xqmQAR8tzFAgo/38we5DeXrcgcqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider-utils": "4.0.9",
-        "ai": "6.0.48",
-        "swr": "^2.2.5",
+        "@ai-sdk/mcp": "2.0.10",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7",
+        "ai": "7.0.22",
+        "swr": "^2.4.1",
         "throttleit": "2.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
@@ -3081,15 +3037,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@orama/orama": {
@@ -8690,9 +8637,9 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
@@ -8717,6 +8664,12 @@
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -8772,19 +8725,18 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.48",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.48.tgz",
-      "integrity": "sha512-nON0rHNTEQgzT1HahGl7AeszJh7es5ibZ6LWqm3IiN+bUAQtXkdArXD9vDlVAPBiCd7ERclZ6lUpOE6ltgJb3w==",
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.22.tgz",
+      "integrity": "sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.22",
-        "@ai-sdk/provider": "3.0.5",
-        "@ai-sdk/provider-utils": "4.0.9",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "4.0.16",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -11352,9 +11304,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -18672,9 +18624,9 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.8.tgz",
-      "integrity": "sha512-gaCPRVoMq8WGDcWj9p4YWzCMPHzE0WNl6W8ADIx9c3JBEIdMkJGMzW+uzXvxHMltwcYACr9jP+32H8/hgwMR7w==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",
@@ -20288,7 +20240,7 @@
     },
     "packages/vercel/core": {
       "name": "@browser-ai/core",
-      "version": "2.1.12",
+      "version": "2.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@mediapipe/tasks-text": "^0.10.22-rc.20250304"
@@ -20306,7 +20258,7 @@
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "ai": "^6.0.0"
+        "ai": "^7.0.0"
       }
     },
     "packages/vercel/core/node_modules/@bcoe/v8-coverage": {
@@ -20707,7 +20659,7 @@
       "name": "@browser-ai/shared",
       "version": "0.0.0",
       "devDependencies": {
-        "@ai-sdk/provider": "^3.0.8",
+        "@ai-sdk/provider": "^4.0.2",
         "@types/node": "^25.2.3",
         "rimraf": "^6.1.2",
         "tsup": "^8.5.1",
@@ -20716,19 +20668,6 @@
       },
       "peerDependencies": {
         "@ai-sdk/provider": "*"
-      }
-    },
-    "packages/vercel/shared/node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/vercel/shared/node_modules/@types/node": {
@@ -20985,7 +20924,7 @@
       },
       "peerDependencies": {
         "@huggingface/transformers": "^3.7.0 || ^4.0.0-next || ^4.0.0",
-        "ai": "^6.0.0"
+        "ai": "^7.0.0"
       }
     },
     "packages/vercel/transformers-js/node_modules/@bcoe/v8-coverage": {
@@ -21384,7 +21323,7 @@
     },
     "packages/vercel/web-llm": {
       "name": "@browser-ai/web-llm",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "@browser-ai/shared": "*",
@@ -21400,7 +21339,7 @@
       },
       "peerDependencies": {
         "@mlc-ai/web-llm": "^0.2.79",
-        "ai": "^6.0.0"
+        "ai": "^7.0.0"
       }
     },
     "packages/vercel/web-llm/node_modules/@bcoe/v8-coverage": {

--- a/packages/vercel/core/README.md
+++ b/packages/vercel/core/README.md
@@ -26,7 +26,7 @@ The `@browser-ai/core` package is the AI SDK provider for your Chrome and Edge b
 
 ## Documentation
 
-For a complete documentation including examples, refer to [this](https://www.browser-ai.dev/docs/ai-sdk-v6/core) site.
+For a complete documentation including examples, refer to [this](https://www.browser-ai.dev/docs/ai-sdk-v7/core) site.
 
 ## Author
 

--- a/packages/vercel/core/package.json
+++ b/packages/vercel/core/package.json
@@ -54,7 +54,7 @@
     "@mediapipe/tasks-text": "^0.10.22-rc.20250304"
   },
   "peerDependencies": {
-    "ai": "^6.0.0"
+    "ai": "^7.0.0"
   },
   "devDependencies": {
     "@browser-ai/shared": "*",

--- a/packages/vercel/core/src/browser-ai-provider.ts
+++ b/packages/vercel/core/src/browser-ai-provider.ts
@@ -1,7 +1,7 @@
 import {
-  EmbeddingModelV3,
+  EmbeddingModelV4,
   NoSuchModelError,
-  ProviderV3,
+  ProviderV4,
 } from "@ai-sdk/provider";
 import {
   BrowserAIChatLanguageModel,
@@ -13,7 +13,7 @@ import {
   BrowserAIEmbeddingModelSettings,
 } from "./embedding/browser-ai-embedding-model";
 
-export interface BrowserAIProvider extends ProviderV3 {
+export interface BrowserAIProvider extends ProviderV4 {
   (
     modelId?: BrowserAIChatModelId,
     settings?: BrowserAIChatSettings,
@@ -38,12 +38,12 @@ export interface BrowserAIProvider extends ProviderV3 {
   embedding(
     modelId: "embedding",
     settings?: BrowserAIEmbeddingModelSettings,
-  ): EmbeddingModelV3;
+  ): EmbeddingModelV4;
 
   embeddingModel: (
     modelId: "embedding",
     settings?: BrowserAIEmbeddingModelSettings,
-  ) => EmbeddingModelV3;
+  ) => EmbeddingModelV4;
 
   // Not implemented
   imageModel(modelId: string): never;
@@ -89,11 +89,13 @@ export function createBrowserAI(
     return createChatModel(modelId, settings);
   };
 
-  provider.specificationVersion = "v3" as const;
+  provider.specificationVersion = "v4" as const;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
   provider.embedding = createEmbeddingModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbedding = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: "imageModel" });

--- a/packages/vercel/core/src/chat/browser-ai-language-model.ts
+++ b/packages/vercel/core/src/chat/browser-ai-language-model.ts
@@ -1,15 +1,15 @@
 import {
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  SharedV3Warning,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3ProviderTool,
-  LanguageModelV3StreamPart,
-  LanguageModelV3ToolCall,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  SharedV4Warning,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4ProviderTool,
+  LanguageModelV4StreamPart,
+  LanguageModelV4ToolCall,
   JSONValue,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamResult,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamResult,
 } from "@ai-sdk/provider";
 import {
   buildJsonToolSystemPrompt,
@@ -67,8 +67,8 @@ type BrowserAIConfig = {
   options: BrowserAIChatSettings;
 };
 
-export class BrowserAIChatLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = "v3";
+export class BrowserAIChatLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = "v4";
   readonly modelId: BrowserAIChatModelId;
   readonly provider = "browser-ai";
 
@@ -112,7 +112,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
     });
   }
 
-  private getArgs(callOptions: Parameters<LanguageModelV3["doGenerate"]>[0]) {
+  private getArgs(callOptions: Parameters<LanguageModelV4["doGenerate"]>[0]) {
     const {
       prompt,
       maxOutputTokens,
@@ -128,7 +128,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
       toolChoice,
       providerOptions,
     } = callOptions;
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
 
     // Gather warnings for unsupported settings
     warnings.push(
@@ -147,7 +147,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
     const functionTools = (tools ?? []).filter(isFunctionTool);
 
     const unsupportedTools = (tools ?? []).filter(
-      (tool): tool is LanguageModelV3ProviderTool => !isFunctionTool(tool),
+      (tool): tool is LanguageModelV4ProviderTool => !isFunctionTool(tool),
     );
 
     for (const tool of unsupportedTools) {
@@ -204,8 +204,8 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
    * @throws {UnsupportedFunctionalityError} When unsupported features like file input are used
    */
   public async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const converted = this.getArgs(options);
     const {
       systemMessage,
@@ -244,7 +244,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
     if (toolCalls.length > 0) {
       const toolCallsToEmit = toolCalls.slice(0, 1);
 
-      const parts: LanguageModelV3Content[] = [];
+      const parts: LanguageModelV4Content[] = [];
 
       if (textContent) {
         parts.push({
@@ -259,7 +259,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
           toolCallId: call.toolCallId,
           toolName: call.toolName,
           input: JSON.stringify(call.args ?? {}),
-        } satisfies LanguageModelV3ToolCall);
+        } satisfies LanguageModelV4ToolCall);
       }
 
       return {
@@ -283,7 +283,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
       };
     }
 
-    const content: LanguageModelV3Content[] = [
+    const content: LanguageModelV4Content[] = [
       {
         type: "text",
         text: textContent || rawResponse,
@@ -380,8 +380,8 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
    * @throws {UnsupportedFunctionalityError} When unsupported features like file input are used
    */
   public async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const converted = this.getArgs(options);
     const {
       systemMessage,
@@ -416,7 +416,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
     const conversationHistory = [...messages];
     const textId = "text-0";
 
-    const stream = new ReadableStream<LanguageModelV3StreamPart>({
+    const stream = new ReadableStream<LanguageModelV4StreamPart>({
       start: async (controller) => {
         controller.enqueue({
           type: "stream-start",
@@ -457,7 +457,7 @@ export class BrowserAIChatLanguageModel implements LanguageModelV3 {
           textStarted = false;
         };
 
-        const finishStream = (finishReason: LanguageModelV3FinishReason) => {
+        const finishStream = (finishReason: LanguageModelV4FinishReason) => {
           if (finished) return;
           finished = true;
           emitTextEndIfNeeded();

--- a/packages/vercel/core/src/embedding/browser-ai-embedding-model.ts
+++ b/packages/vercel/core/src/embedding/browser-ai-embedding-model.ts
@@ -1,7 +1,7 @@
 import {
-  EmbeddingModelV3,
-  EmbeddingModelV3CallOptions,
-  EmbeddingModelV3Result,
+  EmbeddingModelV4,
+  EmbeddingModelV4CallOptions,
+  EmbeddingModelV4Result,
 } from "@ai-sdk/provider";
 import { TextEmbedder } from "@mediapipe/tasks-text";
 
@@ -47,8 +47,8 @@ export interface BrowserAIEmbeddingModelSettings {
 // See more:
 // - https://github.com/google-ai-edge/mediapipe
 // - https://ai.google.dev/edge/mediapipe/solutions/text/text_embedder/web_js
-export class BrowserAIEmbeddingModel implements EmbeddingModelV3 {
-  readonly specificationVersion = "v3";
+export class BrowserAIEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = "v4";
   readonly provider = "google-mediapipe";
   readonly modelId: string = "embedding";
   readonly supportsParallelCalls = true;
@@ -93,8 +93,8 @@ export class BrowserAIEmbeddingModel implements EmbeddingModelV3 {
   };
 
   public doEmbed = async (
-    options: EmbeddingModelV3CallOptions,
-  ): Promise<EmbeddingModelV3Result> => {
+    options: EmbeddingModelV4CallOptions,
+  ): Promise<EmbeddingModelV4Result> => {
     // Note: abortSignal is not supported by MediaPipe TextEmbedder
     if (options.abortSignal?.aborted) {
       throw new Error("Operation was aborted");

--- a/packages/vercel/core/src/utils/convert-to-browser-ai-messages.ts
+++ b/packages/vercel/core/src/utils/convert-to-browser-ai-messages.ts
@@ -1,8 +1,9 @@
 import {
-  LanguageModelV3Prompt,
-  LanguageModelV3ToolCallPart,
-  LanguageModelV3ToolResultPart,
-  LanguageModelV3ToolResultOutput,
+  LanguageModelV4Prompt,
+  LanguageModelV4ToolCallPart,
+  LanguageModelV4ToolResultPart,
+  LanguageModelV4ToolResultOutput,
+  SharedV4FileData,
   UnsupportedFunctionalityError,
 } from "@ai-sdk/provider";
 import { formatToolResults, type ToolResult } from "@browser-ai/shared";
@@ -29,28 +30,33 @@ function convertBase64ToUint8Array(base64: string): Uint8Array {
  * Browser AI supports: Blob, BufferSource (Uint8Array), URLs
  */
 function convertFileData(
-  data: URL | Uint8Array | string,
+  data: SharedV4FileData,
   mediaType: string,
 ): Uint8Array | string {
-  // Handle different data types from Vercel AI SDK
-  if (data instanceof URL) {
-    // URLs - keep as string (if supported by provider)
-    return data.toString();
-  }
+  switch (data.type) {
+    case "url":
+      // URLs - keep as string (if supported by provider)
+      return data.url.toString();
 
-  if (data instanceof Uint8Array) {
-    // Already in correct format
-    return data;
-  }
+    case "data":
+      return data.data instanceof Uint8Array
+        ? data.data
+        : // Base64 string from AI SDK - convert to Uint8Array
+          convertBase64ToUint8Array(data.data);
 
-  if (typeof data === "string") {
-    // Base64 string from AI SDK - convert to Uint8Array
-    return convertBase64ToUint8Array(data);
-  }
+    case "text":
+    case "reference":
+      throw new UnsupportedFunctionalityError({
+        functionality: `file data type '${data.type}' for ${mediaType}`,
+      });
 
-  // Exhaustive check - this should never happen with the union type
-  const exhaustiveCheck: never = data;
-  throw new Error(`Unexpected data type for ${mediaType}: ${exhaustiveCheck}`);
+    default: {
+      const exhaustiveCheck: never = data;
+      throw new Error(
+        `Unexpected data type for ${mediaType}: ${JSON.stringify(exhaustiveCheck)}`,
+      );
+    }
+  }
 }
 
 function normalizeToolArguments(input: unknown): unknown {
@@ -69,7 +75,7 @@ function normalizeToolArguments(input: unknown): unknown {
   return input ?? {};
 }
 
-function formatToolCallsJson(parts: LanguageModelV3ToolCallPart[]): string {
+function formatToolCallsJson(parts: LanguageModelV4ToolCallPart[]): string {
   if (!parts.length) {
     return "";
   }
@@ -92,7 +98,7 @@ ${payloads.join("\n")}
 \`\`\``;
 }
 
-function convertToolResultOutput(output: LanguageModelV3ToolResultOutput): {
+function convertToolResultOutput(output: LanguageModelV4ToolResultOutput): {
   value: unknown;
   isError: boolean;
 } {
@@ -116,7 +122,7 @@ function convertToolResultOutput(output: LanguageModelV3ToolResultOutput): {
   }
 }
 
-function toToolResult(part: LanguageModelV3ToolResultPart): ToolResult {
+function toToolResult(part: LanguageModelV4ToolResultPart): ToolResult {
   const { value, isError } = convertToolResultOutput(part.output);
   return {
     toolCallId: part.toolCallId,
@@ -131,7 +137,7 @@ function toToolResult(part: LanguageModelV3ToolResultPart): ToolResult {
  * Returns system message (for initialPrompts) and regular messages (for prompt method)
  */
 export function convertToBrowserAIMessages(
-  prompt: LanguageModelV3Prompt,
+  prompt: LanguageModelV4Prompt,
 ): ConvertedMessages {
   const normalizedPrompt = prompt.slice();
 
@@ -196,7 +202,7 @@ export function convertToBrowserAIMessages(
 
       case "assistant": {
         let text = "";
-        const toolCallParts: LanguageModelV3ToolCallPart[] = [];
+        const toolCallParts: LanguageModelV4ToolCallPart[] = [];
 
         for (const part of message.content) {
           switch (part.type) {
@@ -221,6 +227,16 @@ export function convertToBrowserAIMessages(
               throw new UnsupportedFunctionalityError({
                 functionality:
                   "tool-result parts in assistant messages (should be in tool messages)",
+              });
+            }
+            case "reasoning-file": {
+              throw new UnsupportedFunctionalityError({
+                functionality: "assistant reasoning file attachments",
+              });
+            }
+            case "custom": {
+              throw new UnsupportedFunctionalityError({
+                functionality: `custom content part: ${part.kind}`,
               });
             }
             default: {
@@ -257,7 +273,7 @@ export function convertToBrowserAIMessages(
       }
 
       case "tool": {
-        const toolParts = message.content as LanguageModelV3ToolResultPart[];
+        const toolParts = message.content as LanguageModelV4ToolResultPart[];
         const results: ToolResult[] = toolParts.map(toToolResult);
         const toolResultsJson = formatToolResults(results);
 

--- a/packages/vercel/core/src/utils/prompt-utils.ts
+++ b/packages/vercel/core/src/utils/prompt-utils.ts
@@ -2,7 +2,7 @@
  * Utilities for prompt processing and transformation
  */
 
-import type { LanguageModelV3Prompt } from "@ai-sdk/provider";
+import type { LanguageModelV4Prompt } from "@ai-sdk/provider";
 
 /**
  * Detect multimodal content and collect expected input types in a single pass.
@@ -10,7 +10,7 @@ import type { LanguageModelV3Prompt } from "@ai-sdk/provider";
  * @param prompt - The prompt to analyze
  * @returns hasMultiModalInput flag and the expectedInputs array (undefined when text-only)
  */
-export function getMultimodalInfo(prompt: LanguageModelV3Prompt): {
+export function getMultimodalInfo(prompt: LanguageModelV4Prompt): {
   hasMultiModalInput: boolean;
   expectedInputs: Array<{ type: "text" | "image" | "audio" }> | undefined;
 } {

--- a/packages/vercel/core/src/utils/warnings.ts
+++ b/packages/vercel/core/src/utils/warnings.ts
@@ -2,7 +2,7 @@
  * Warning generation utilities for unsupported settings and tools
  */
 
-import type { SharedV3Warning } from "@ai-sdk/provider";
+import type { SharedV4Warning } from "@ai-sdk/provider";
 import { createUnsupportedSettingWarning } from "@browser-ai/shared";
 
 // Re-export shared utilities
@@ -35,8 +35,8 @@ export function gatherUnsupportedSettingWarnings(options: {
   frequencyPenalty?: number;
   seed?: number;
   toolChoice?: unknown;
-}): SharedV3Warning[] {
-  const warnings: SharedV3Warning[] = [];
+}): SharedV4Warning[] {
+  const warnings: SharedV4Warning[] = [];
 
   if (options.maxOutputTokens != null) {
     warnings.push(

--- a/packages/vercel/core/test/browser-ai-embedding-model.test.ts
+++ b/packages/vercel/core/test/browser-ai-embedding-model.test.ts
@@ -60,7 +60,7 @@ describe("BrowserAIEmbeddingModel", () => {
       expect(model).toBeInstanceOf(BrowserAIEmbeddingModel);
       expect(model.modelId).toBe("embedding");
       expect(model.provider).toBe("google-mediapipe");
-      expect(model.specificationVersion).toBe("v3");
+      expect(model.specificationVersion).toBe("v4");
       expect(model.supportsParallelCalls).toBe(true);
       expect(model.maxEmbeddingsPerCall).toBeUndefined();
     });

--- a/packages/vercel/core/test/browser-ai-language-model.test.ts
+++ b/packages/vercel/core/test/browser-ai-language-model.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../src/chat/browser-ai-language-model";
 
 import { generateText, streamText, Output } from "ai";
-import { LanguageModelV3StreamPart, LoadSettingError } from "@ai-sdk/provider";
+import { LanguageModelV4StreamPart, LoadSettingError } from "@ai-sdk/provider";
 import { z } from "zod";
 
 describe("BrowserAIChatLanguageModel", () => {
@@ -43,7 +43,7 @@ describe("BrowserAIChatLanguageModel", () => {
     expect(model).toBeInstanceOf(BrowserAIChatLanguageModel);
     expect(model.modelId).toBe("text");
     expect(model.provider).toBe("browser-ai");
-    expect(model.specificationVersion).toBe("v3");
+    expect(model.specificationVersion).toBe("v4");
   });
   it("should throw when LanguageModel is not available", async () => {
     vi.stubGlobal("LanguageModel", undefined);
@@ -93,10 +93,8 @@ describe("BrowserAIChatLanguageModel", () => {
 
     const result = await generateText({
       model: new BrowserAIChatLanguageModel("text"),
-      messages: [
-        { role: "system", content: "You are a helpful assistant." },
-        { role: "user", content: "Who are you?" },
-      ],
+      instructions: "You are a helpful assistant.",
+      messages: [{ role: "user", content: "Who are you?" }],
     });
 
     expect(result.text).toBe("I am a helpful assistant.");
@@ -626,7 +624,7 @@ Running the tool now.`;
         ],
       });
 
-      const events: LanguageModelV3StreamPart[] = [];
+      const events: LanguageModelV4StreamPart[] = [];
       const reader = stream.getReader();
       while (true) {
         const { done, value } = await reader.read();
@@ -642,7 +640,7 @@ Running the tool now.`;
           (
             event,
           ): event is Extract<
-            LanguageModelV3StreamPart,
+            LanguageModelV4StreamPart,
             { type: "text-delta" }
           > => event.type === "text-delta",
         )
@@ -655,7 +653,7 @@ Running the tool now.`;
       const toolEvent = events.find(
         (
           event,
-        ): event is Extract<LanguageModelV3StreamPart, { type: "tool-call" }> =>
+        ): event is Extract<LanguageModelV4StreamPart, { type: "tool-call" }> =>
           event.type === "tool-call",
       );
 
@@ -668,7 +666,7 @@ Running the tool now.`;
       const finishEvent = events.find(
         (
           event,
-        ): event is Extract<LanguageModelV3StreamPart, { type: "finish" }> =>
+        ): event is Extract<LanguageModelV4StreamPart, { type: "finish" }> =>
           event.type === "finish",
       );
 
@@ -745,7 +743,7 @@ Running the tool now.`;
         ],
       });
 
-      const events: LanguageModelV3StreamPart[] = [];
+      const events: LanguageModelV4StreamPart[] = [];
       const reader = stream.getReader();
       while (true) {
         const { done, value } = await reader.read();
@@ -808,7 +806,7 @@ Running the tool now.`;
         ],
       });
 
-      const events: LanguageModelV3StreamPart[] = [];
+      const events: LanguageModelV4StreamPart[] = [];
       const reader = stream.getReader();
       while (true) {
         const { done, value } = await reader.read();
@@ -821,7 +819,7 @@ Running the tool now.`;
         (
           event,
         ): event is Extract<
-          LanguageModelV3StreamPart,
+          LanguageModelV4StreamPart,
           { type: "tool-input-start" }
         > => event.type === "tool-input-start",
       );
@@ -829,7 +827,7 @@ Running the tool now.`;
         (
           event,
         ): event is Extract<
-          LanguageModelV3StreamPart,
+          LanguageModelV4StreamPart,
           { type: "tool-input-delta" }
         > => event.type === "tool-input-delta",
       );
@@ -837,14 +835,14 @@ Running the tool now.`;
         (
           event,
         ): event is Extract<
-          LanguageModelV3StreamPart,
+          LanguageModelV4StreamPart,
           { type: "tool-input-end" }
         > => event.type === "tool-input-end",
       );
       const toolCallEvent = events.find(
         (
           event,
-        ): event is Extract<LanguageModelV3StreamPart, { type: "tool-call" }> =>
+        ): event is Extract<LanguageModelV4StreamPart, { type: "tool-call" }> =>
           event.type === "tool-call",
       );
 
@@ -1053,7 +1051,7 @@ Running the tool now.`;
         abortSignal: abortController.signal,
       });
 
-      const events: LanguageModelV3StreamPart[] = [];
+      const events: LanguageModelV4StreamPart[] = [];
       const reader = stream.getReader();
       while (true) {
         const { done, value } = await reader.read();
@@ -1062,7 +1060,7 @@ Running the tool now.`;
       }
 
       const errorEvent = events.find((e) => e.type === "error") as Extract<
-        LanguageModelV3StreamPart,
+        LanguageModelV4StreamPart,
         { type: "error" }
       >;
       expect(errorEvent).toBeDefined();

--- a/packages/vercel/core/test/convert-to-browser-ai-messages.test.ts
+++ b/packages/vercel/core/test/convert-to-browser-ai-messages.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { convertToBrowserAIMessages } from "../src/utils/convert-to-browser-ai-messages";
 import {
-  LanguageModelV3Prompt,
-  LanguageModelV3Message,
+  LanguageModelV4Prompt,
+  LanguageModelV4Message,
   UnsupportedFunctionalityError,
 } from "@ai-sdk/provider";
 
 describe("convertToBrowserAIMessages", () => {
   describe("text messages", () => {
     it("should convert simple text user message", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [{ type: "text", text: "Hello, world!" }],
@@ -28,7 +28,7 @@ describe("convertToBrowserAIMessages", () => {
     });
 
     it("should extract system message", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "system",
           content: "You are a helpful assistant.",
@@ -51,7 +51,7 @@ describe("convertToBrowserAIMessages", () => {
     });
 
     it("should convert assistant messages", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [{ type: "text", text: "Hello!" }],
@@ -80,7 +80,7 @@ describe("convertToBrowserAIMessages", () => {
   describe("image file conversion", () => {
     it("should convert base64 image data to Uint8Array", () => {
       const base64Data = "SGVsbG8gV29ybGQ="; // "Hello World" in base64
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
@@ -88,7 +88,7 @@ describe("convertToBrowserAIMessages", () => {
             {
               type: "file",
               mediaType: "image/png",
-              data: base64Data,
+              data: { type: "data", data: base64Data },
             },
           ],
         },
@@ -116,14 +116,14 @@ describe("convertToBrowserAIMessages", () => {
 
     it("should handle Uint8Array image data directly", () => {
       const uint8Data = new Uint8Array([1, 2, 3, 4]);
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
             {
               type: "file",
               mediaType: "image/jpeg",
-              data: uint8Data,
+              data: { type: "data", data: uint8Data },
             },
           ],
         },
@@ -139,14 +139,14 @@ describe("convertToBrowserAIMessages", () => {
 
     it("should handle URL image data", () => {
       const imageUrl = new URL("https://example.com/image.png");
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
             {
               type: "file",
               mediaType: "image/webp",
-              data: imageUrl,
+              data: { type: "url", url: imageUrl },
             },
           ],
         },
@@ -164,7 +164,7 @@ describe("convertToBrowserAIMessages", () => {
   describe("audio file conversion", () => {
     it("should convert base64 audio data to Uint8Array", () => {
       const base64Data = "UklGRnQAAABXQVZF"; // Valid WAV header start in base64
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
@@ -172,7 +172,7 @@ describe("convertToBrowserAIMessages", () => {
             {
               type: "file",
               mediaType: "audio/wav",
-              data: base64Data,
+              data: { type: "data", data: base64Data },
             },
           ],
         },
@@ -188,14 +188,14 @@ describe("convertToBrowserAIMessages", () => {
 
     it("should handle Uint8Array audio data directly", () => {
       const audioData = new Uint8Array([82, 73, 70, 70]); // "RIFF" header
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
             {
               type: "file",
               mediaType: "audio/mp3",
-              data: audioData,
+              data: { type: "data", data: audioData },
             },
           ],
         },
@@ -212,7 +212,7 @@ describe("convertToBrowserAIMessages", () => {
 
   describe("mixed content", () => {
     it("should handle mixed text, image, and audio content", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
@@ -220,13 +220,13 @@ describe("convertToBrowserAIMessages", () => {
             {
               type: "file",
               mediaType: "image/png",
-              data: "SGVsbG8=", // "Hello" in base64
+              data: { type: "data", data: "SGVsbG8=" }, // "Hello" in base64
             },
             { type: "text", text: "And this audio:" },
             {
               type: "file",
               mediaType: "audio/wav",
-              data: new Uint8Array([1, 2, 3]),
+              data: { type: "data", data: new Uint8Array([1, 2, 3]) },
             },
           ],
         },
@@ -256,7 +256,7 @@ describe("convertToBrowserAIMessages", () => {
 
   describe("tool support", () => {
     it("should convert assistant tool calls into toolCall fences", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "assistant",
           content: [
@@ -268,11 +268,11 @@ describe("convertToBrowserAIMessages", () => {
               input: { location: "Seattle" },
             },
           ],
-        } as LanguageModelV3Message,
+        } as LanguageModelV4Message,
         {
           role: "user",
           content: [{ type: "text", text: "Thanks!" }],
-        } as LanguageModelV3Message,
+        } as LanguageModelV4Message,
       ];
 
       const result = convertToBrowserAIMessages(prompt);
@@ -289,7 +289,7 @@ describe("convertToBrowserAIMessages", () => {
     });
 
     it("should serialize scalar tool inputs as JSON strings", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "assistant",
           content: [
@@ -300,11 +300,11 @@ describe("convertToBrowserAIMessages", () => {
               input: "Zurich",
             },
           ],
-        } as LanguageModelV3Message,
+        } as LanguageModelV4Message,
         {
           role: "user",
           content: [{ type: "text", text: "Appreciate it." }],
-        } as LanguageModelV3Message,
+        } as LanguageModelV4Message,
       ];
 
       const result = convertToBrowserAIMessages(prompt);
@@ -321,7 +321,7 @@ describe("convertToBrowserAIMessages", () => {
     });
 
     it("should handle parameter names with special characters", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "assistant",
           content: [
@@ -332,11 +332,11 @@ describe("convertToBrowserAIMessages", () => {
               input: { "123-name": "Alice" },
             },
           ],
-        } as LanguageModelV3Message,
+        } as LanguageModelV4Message,
         {
           role: "user",
           content: [{ type: "text", text: "Continue." }],
-        } as LanguageModelV3Message,
+        } as LanguageModelV4Message,
       ];
 
       const result = convertToBrowserAIMessages(prompt);
@@ -346,7 +346,7 @@ describe("convertToBrowserAIMessages", () => {
     });
 
     it("should deserialize JSON-stringified tool inputs", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "assistant",
           content: [
@@ -357,7 +357,7 @@ describe("convertToBrowserAIMessages", () => {
               input: JSON.stringify({ query: "status:open", limit: 5 }),
             },
           ],
-        } as LanguageModelV3Message,
+        } as LanguageModelV4Message,
       ];
 
       const result = convertToBrowserAIMessages(prompt);
@@ -369,7 +369,7 @@ describe("convertToBrowserAIMessages", () => {
     });
 
     it("should serialize multiple tool calls within a single fence", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "assistant",
           content: [
@@ -386,7 +386,7 @@ describe("convertToBrowserAIMessages", () => {
               input: { value: 2 },
             },
           ],
-        } as LanguageModelV3Message,
+        } as LanguageModelV4Message,
       ];
 
       const result = convertToBrowserAIMessages(prompt);
@@ -400,7 +400,7 @@ describe("convertToBrowserAIMessages", () => {
     });
 
     it("should retain a trailing assistant tool call message", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "assistant",
           content: [
@@ -412,7 +412,7 @@ describe("convertToBrowserAIMessages", () => {
               input: { location: "Seattle" },
             },
           ],
-        } as LanguageModelV3Message,
+        } as LanguageModelV4Message,
       ];
 
       const result = convertToBrowserAIMessages(prompt);
@@ -426,7 +426,7 @@ describe("convertToBrowserAIMessages", () => {
     });
 
     it("should convert tool results into user tool_result blocks", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "tool",
           content: [
@@ -440,7 +440,7 @@ describe("convertToBrowserAIMessages", () => {
               },
             },
           ],
-        } as LanguageModelV3Message,
+        } as LanguageModelV4Message,
       ];
 
       const result = convertToBrowserAIMessages(prompt);
@@ -457,14 +457,14 @@ describe("convertToBrowserAIMessages", () => {
 
   describe("error handling", () => {
     it("should throw for unsupported file types", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
             {
               type: "file",
               mediaType: "video/mp4",
-              data: "some data",
+              data: { type: "data", data: "some data" },
             },
           ],
         },
@@ -482,11 +482,11 @@ describe("convertToBrowserAIMessages", () => {
           content: [
             {
               type: "unsupported" as any,
-              data: "some data",
+              data: { type: "data", data: "some data" },
             },
           ],
         },
-      ] as LanguageModelV3Prompt;
+      ] as LanguageModelV4Prompt;
 
       expect(() => convertToBrowserAIMessages(prompt)).toThrow(
         UnsupportedFunctionalityError,
@@ -494,14 +494,14 @@ describe("convertToBrowserAIMessages", () => {
     });
 
     it("should throw for invalid base64 data", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
             {
               type: "file",
               mediaType: "image/png",
-              data: "invalid-base64-data!@#",
+              data: { type: "data", data: "invalid-base64-data!@#" },
             },
           ],
         },
@@ -520,7 +520,7 @@ describe("convertToBrowserAIMessages", () => {
     });
 
     it("should handle empty content arrays", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [],

--- a/packages/vercel/core/test/prompt-utils.test.ts
+++ b/packages/vercel/core/test/prompt-utils.test.ts
@@ -23,7 +23,11 @@ describe("prompt-utils", () => {
           role: "user",
           content: [
             { type: "text", text: "What's in this image?" },
-            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "image/png" },
+            {
+              type: "file",
+              data: { type: "data", data: new Uint8Array() },
+              mediaType: "image/png",
+            },
           ],
         },
       ];
@@ -38,7 +42,11 @@ describe("prompt-utils", () => {
         {
           role: "user",
           content: [
-            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "audio/wav" },
+            {
+              type: "file",
+              data: { type: "data", data: new Uint8Array() },
+              mediaType: "audio/wav",
+            },
           ],
         },
       ];
@@ -53,8 +61,16 @@ describe("prompt-utils", () => {
         {
           role: "user",
           content: [
-            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "image/png" },
-            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "audio/wav" },
+            {
+              type: "file",
+              data: { type: "data", data: new Uint8Array() },
+              mediaType: "image/png",
+            },
+            {
+              type: "file",
+              data: { type: "data", data: new Uint8Array() },
+              mediaType: "audio/wav",
+            },
           ],
         },
       ];
@@ -70,8 +86,16 @@ describe("prompt-utils", () => {
         {
           role: "user",
           content: [
-            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "image/png" },
-            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "image/jpeg" },
+            {
+              type: "file",
+              data: { type: "data", data: new Uint8Array() },
+              mediaType: "image/png",
+            },
+            {
+              type: "file",
+              data: { type: "data", data: new Uint8Array() },
+              mediaType: "image/jpeg",
+            },
           ],
         },
       ];

--- a/packages/vercel/core/test/prompt-utils.test.ts
+++ b/packages/vercel/core/test/prompt-utils.test.ts
@@ -3,12 +3,12 @@ import {
   getMultimodalInfo,
   prependSystemPromptToMessages,
 } from "../src/utils/prompt-utils";
-import type { LanguageModelV3Prompt } from "@ai-sdk/provider";
+import type { LanguageModelV4Prompt } from "@ai-sdk/provider";
 
 describe("prompt-utils", () => {
   describe("getMultimodalInfo", () => {
     it("returns hasMultiModalInput=false and no expectedInputs for text-only prompt", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         { role: "user", content: [{ type: "text", text: "Hello" }] },
       ];
       expect(getMultimodalInfo(prompt)).toEqual({
@@ -18,12 +18,12 @@ describe("prompt-utils", () => {
     });
 
     it("detects image file", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
             { type: "text", text: "What's in this image?" },
-            { type: "file", data: new Uint8Array(), mediaType: "image/png" },
+            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "image/png" },
           ],
         },
       ];
@@ -34,11 +34,11 @@ describe("prompt-utils", () => {
     });
 
     it("detects audio file", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
-            { type: "file", data: new Uint8Array(), mediaType: "audio/wav" },
+            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "audio/wav" },
           ],
         },
       ];
@@ -49,12 +49,12 @@ describe("prompt-utils", () => {
     });
 
     it("detects both image and audio when both present", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
-            { type: "file", data: new Uint8Array(), mediaType: "image/png" },
-            { type: "file", data: new Uint8Array(), mediaType: "audio/wav" },
+            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "image/png" },
+            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "audio/wav" },
           ],
         },
       ];
@@ -66,12 +66,12 @@ describe("prompt-utils", () => {
     });
 
     it("deduplicates multiple images", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
-            { type: "file", data: new Uint8Array(), mediaType: "image/png" },
-            { type: "file", data: new Uint8Array(), mediaType: "image/jpeg" },
+            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "image/png" },
+            { type: "file", data: { type: "data", data: new Uint8Array() }, mediaType: "image/jpeg" },
           ],
         },
       ];
@@ -82,13 +82,13 @@ describe("prompt-utils", () => {
     });
 
     it("ignores files with unknown media types", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
             {
               type: "file",
-              data: new Uint8Array(),
+              data: { type: "data", data: new Uint8Array() },
               mediaType: "application/pdf",
             },
           ],
@@ -101,14 +101,14 @@ describe("prompt-utils", () => {
     });
 
     it("ignores files on assistant messages (only checks user messages)", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         { role: "user", content: [{ type: "text", text: "Hello" }] },
         {
           role: "assistant",
           content: [
             {
               type: "file" as any,
-              data: new Uint8Array(),
+              data: { type: "data", data: new Uint8Array() },
               mediaType: "image/png",
             },
           ],

--- a/packages/vercel/core/test/warnings.test.ts
+++ b/packages/vercel/core/test/warnings.test.ts
@@ -4,7 +4,7 @@ import {
   createUnsupportedToolWarning,
   gatherUnsupportedSettingWarnings,
 } from "../src/utils/warnings";
-import type { LanguageModelV3ProviderTool } from "@ai-sdk/provider";
+import type { LanguageModelV4ProviderTool } from "@ai-sdk/provider";
 
 describe("warnings", () => {
   describe("createUnsupportedSettingWarning", () => {
@@ -37,7 +37,7 @@ describe("warnings", () => {
 
   describe("createUnsupportedToolWarning", () => {
     it("should create a warning with tool information", () => {
-      const mockTool: LanguageModelV3ProviderTool = {
+      const mockTool: LanguageModelV4ProviderTool = {
         type: "provider",
         id: "test.tool",
         name: "testTool",

--- a/packages/vercel/shared/package.json
+++ b/packages/vercel/shared/package.json
@@ -34,7 +34,7 @@
     "@ai-sdk/provider": "*"
   },
   "devDependencies": {
-    "@ai-sdk/provider": "^3.0.8",
+    "@ai-sdk/provider": "^4.0.2",
     "@types/node": "^25.2.3",
     "rimraf": "^6.1.2",
     "tsup": "^8.5.1",

--- a/packages/vercel/shared/src/streaming/stream-processor.ts
+++ b/packages/vercel/shared/src/streaming/stream-processor.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
 import { ToolCallFenceDetector } from "./tool-call-detector";
 import {
   createArgumentsStreamState,
@@ -31,7 +31,7 @@ export function generateToolCallId(): string {
 export async function processToolCallStream(
   chunks: AsyncIterable<string>,
   emitTextDelta: (delta: string) => void,
-  controller: ReadableStreamDefaultController<LanguageModelV3StreamPart>,
+  controller: ReadableStreamDefaultController<LanguageModelV4StreamPart>,
   options?: { stopEarlyOnToolCall?: boolean },
 ): Promise<ToolCallStreamResult> {
   const fenceDetector = new ToolCallFenceDetector();

--- a/packages/vercel/shared/src/tool-calling/build-json-system-prompt.ts
+++ b/packages/vercel/shared/src/tool-calling/build-json-system-prompt.ts
@@ -1,6 +1,6 @@
 import type {
   JSONSchema7,
-  LanguageModelV3FunctionTool,
+  LanguageModelV4FunctionTool,
 } from "@ai-sdk/provider";
 import type { ToolDefinition } from "../types";
 
@@ -15,7 +15,7 @@ import type { ToolDefinition } from "../types";
  */
 export function buildJsonToolSystemPrompt(
   originalSystemPrompt: string | undefined,
-  tools: Array<ToolDefinition | LanguageModelV3FunctionTool>,
+  tools: Array<ToolDefinition | LanguageModelV4FunctionTool>,
   options?: { allowParallelToolCalls?: boolean },
 ): string {
   if (!tools || tools.length === 0) {
@@ -71,13 +71,13 @@ Important:
 
 /**
  * Extracts the parameters/input schema from a tool definition.
- * Handles both ToolDefinition (parameters field) and LanguageModelV3FunctionTool (inputSchema field).
+ * Handles both ToolDefinition (parameters field) and LanguageModelV4FunctionTool (inputSchema field).
  *
  * @param tool - The tool definition to extract parameters from
  * @returns The JSON Schema for the tool's parameters, or undefined if not present
  */
 function getParameters(
-  tool: ToolDefinition | LanguageModelV3FunctionTool,
+  tool: ToolDefinition | LanguageModelV4FunctionTool,
 ): JSONSchema7 | undefined {
   if ("parameters" in tool) {
     return tool.parameters;

--- a/packages/vercel/shared/src/types/tool-calling.ts
+++ b/packages/vercel/shared/src/types/tool-calling.ts
@@ -1,6 +1,6 @@
 import type {
   JSONSchema7,
-  LanguageModelV3FunctionTool,
+  LanguageModelV4FunctionTool,
 } from "@ai-sdk/provider";
 
 /**
@@ -13,7 +13,7 @@ export type JSONSchema = JSONSchema7;
  * Tool definition in AI SDK format (function tools only)
  */
 export type ToolDefinition = Pick<
-  LanguageModelV3FunctionTool,
+  LanguageModelV4FunctionTool,
   "name" | "description"
 > & {
   parameters: JSONSchema7;

--- a/packages/vercel/shared/src/utils/tool-utils.ts
+++ b/packages/vercel/shared/src/utils/tool-utils.ts
@@ -3,18 +3,18 @@
  */
 
 import type {
-  LanguageModelV3FunctionTool,
-  LanguageModelV3ProviderTool,
+  LanguageModelV4FunctionTool,
+  LanguageModelV4ProviderTool,
 } from "@ai-sdk/provider";
 
 /**
  * Type guard to check if a tool is a function tool
  *
  * @param tool - The tool to check
- * @returns true if the tool is a LanguageModelV3FunctionTool
+ * @returns true if the tool is a LanguageModelV4FunctionTool
  */
 export function isFunctionTool(
-  tool: LanguageModelV3FunctionTool | LanguageModelV3ProviderTool,
-): tool is LanguageModelV3FunctionTool {
+  tool: LanguageModelV4FunctionTool | LanguageModelV4ProviderTool,
+): tool is LanguageModelV4FunctionTool {
   return tool.type === "function";
 }

--- a/packages/vercel/shared/src/utils/warnings.ts
+++ b/packages/vercel/shared/src/utils/warnings.ts
@@ -3,8 +3,8 @@
  */
 
 import type {
-  SharedV3Warning,
-  LanguageModelV3ProviderTool,
+  SharedV4Warning,
+  LanguageModelV4ProviderTool,
 } from "@ai-sdk/provider";
 
 /**
@@ -25,7 +25,7 @@ import type {
 export function createUnsupportedSettingWarning(
   feature: string,
   details: string,
-): SharedV3Warning {
+): SharedV4Warning {
   return {
     type: "unsupported",
     feature,
@@ -49,9 +49,9 @@ export function createUnsupportedSettingWarning(
  * ```
  */
 export function createUnsupportedToolWarning(
-  tool: LanguageModelV3ProviderTool,
+  tool: LanguageModelV4ProviderTool,
   details: string,
-): SharedV3Warning {
+): SharedV4Warning {
   return {
     type: "unsupported",
     feature: `tool:${tool.name}`,

--- a/packages/vercel/shared/test/stream-processor.test.ts
+++ b/packages/vercel/shared/test/stream-processor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
 import {
   processToolCallStream,
   generateToolCallId,
@@ -10,10 +10,10 @@ async function* makeChunks(strings: string[]): AsyncIterable<string> {
 }
 
 function makeController() {
-  const events: LanguageModelV3StreamPart[] = [];
+  const events: LanguageModelV4StreamPart[] = [];
   const controller = {
-    enqueue: (event: LanguageModelV3StreamPart) => events.push(event),
-  } as unknown as ReadableStreamDefaultController<LanguageModelV3StreamPart>;
+    enqueue: (event: LanguageModelV4StreamPart) => events.push(event),
+  } as unknown as ReadableStreamDefaultController<LanguageModelV4StreamPart>;
   return { controller, events };
 }
 
@@ -80,7 +80,7 @@ describe("processToolCallStream — valid tool call", () => {
   it("emits a tool-call event with correct fields", async () => {
     const { events } = await run([FENCE]);
     const ev = events.find((e) => e.type === "tool-call") as Extract<
-      LanguageModelV3StreamPart,
+      LanguageModelV4StreamPart,
       { type: "tool-call" }
     >;
     expect(ev.toolName).toBe("search");
@@ -127,7 +127,7 @@ describe("processToolCallStream — chunked tool call", () => {
       ' "v"}}\n```',
     ]);
     const startEvent = events.find((e) => e.type === "tool-input-start") as
-      | Extract<LanguageModelV3StreamPart, { type: "tool-input-start" }>
+      | Extract<LanguageModelV4StreamPart, { type: "tool-input-start" }>
       | undefined;
     expect(startEvent).toBeDefined();
     expect(startEvent!.toolName).toBe("early_name");

--- a/packages/vercel/shared/test/stream-processor.test.ts
+++ b/packages/vercel/shared/test/stream-processor.test.ts
@@ -38,7 +38,7 @@ async function run(
   return { result, events, text: getText() };
 }
 
-describe("processToolCallStream — plain text", () => {
+describe("processToolCallStream - plain text", () => {
   it("emits text via emitTextDelta, no tool detection", async () => {
     const { result, text } = await run(["Hello", " world"]);
     expect(result.toolCallDetected).toBe(false);
@@ -53,7 +53,7 @@ describe("processToolCallStream — plain text", () => {
   });
 });
 
-describe("processToolCallStream — valid tool call", () => {
+describe("processToolCallStream - valid tool call", () => {
   const FENCE =
     '```tool_call\n{"name": "search", "arguments": {"q": "test"}}\n```';
 
@@ -107,7 +107,7 @@ describe("processToolCallStream — valid tool call", () => {
   });
 });
 
-describe("processToolCallStream — chunked tool call", () => {
+describe("processToolCallStream - chunked tool call", () => {
   it("assembles a tool call from multiple chunks", async () => {
     const { result } = await run([
       "```tool_call\n",
@@ -134,7 +134,7 @@ describe("processToolCallStream — chunked tool call", () => {
   });
 });
 
-describe("processToolCallStream — text around tool calls", () => {
+describe("processToolCallStream - text around tool calls", () => {
   it("emits text before the fence via emitTextDelta", async () => {
     const { text } = await run([
       'Before. ```tool_call\n{"name": "t", "arguments": {}}\n```',
@@ -151,7 +151,7 @@ describe("processToolCallStream — text around tool calls", () => {
   });
 });
 
-describe("processToolCallStream — malformed fence", () => {
+describe("processToolCallStream - malformed fence", () => {
   it("treats a fence with non-JSON content as plain text", async () => {
     const { result, text } = await run(["```tool_call\nnot json\n```"]);
     expect(result.toolCallDetected).toBe(false);
@@ -166,7 +166,7 @@ describe("processToolCallStream — malformed fence", () => {
   });
 });
 
-describe("processToolCallStream — stopEarlyOnToolCall", () => {
+describe("processToolCallStream - stopEarlyOnToolCall", () => {
   function makeTrackedChunks(strings: string[]) {
     const consumed: string[] = [];
     async function* gen() {
@@ -204,7 +204,7 @@ describe("processToolCallStream — stopEarlyOnToolCall", () => {
   });
 });
 
-describe("processToolCallStream — call:name{params} style", () => {
+describe("processToolCallStream - call:name{params} style", () => {
   const FENCE = "<|tool_call>call:randomNumber{max:6,min:1}<tool_call|>";
 
   it("detects the tool call and parses parameters", async () => {
@@ -241,7 +241,7 @@ describe("processToolCallStream — call:name{params} style", () => {
   });
 });
 
-describe("processToolCallStream — edge cases", () => {
+describe("processToolCallStream - edge cases", () => {
   it("only uses the first tool call from a multi-call fence", async () => {
     const { result } = await run([
       '```tool_call\n[{"name": "a", "arguments": {}}, {"name": "b", "arguments": {}}]\n```',

--- a/packages/vercel/transformers-js/README.md
+++ b/packages/vercel/transformers-js/README.md
@@ -26,7 +26,7 @@ The `@browser-ai/transformers-js` package is the AI SDK provider for Transformer
 
 ## Documentation
 
-For a complete documentation including examples, refer to [this](https://www.browser-ai.dev/docs/ai-sdk-v6/transformers-js) site.
+For a complete documentation including examples, refer to [this](https://www.browser-ai.dev/docs/ai-sdk-v7/transformers-js) site.
 
 ## Author
 

--- a/packages/vercel/transformers-js/package.json
+++ b/packages/vercel/transformers-js/package.json
@@ -54,7 +54,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@huggingface/transformers": "^3.7.0 || ^4.0.0-next || ^4.0.0",
-    "ai": "^6.0.0"
+    "ai": "^7.0.0"
   },
   "devDependencies": {
     "@browser-ai/shared": "*",

--- a/packages/vercel/transformers-js/src/chat/transformers-js-language-model.ts
+++ b/packages/vercel/transformers-js/src/chat/transformers-js-language-model.ts
@@ -1,14 +1,14 @@
 import {
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  SharedV3Warning,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3ProviderTool,
-  LanguageModelV3StreamPart,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  SharedV4Warning,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4ProviderTool,
+  LanguageModelV4StreamPart,
   LoadSettingError,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamResult,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamResult,
 } from "@ai-sdk/provider";
 import {
   AutoTokenizer,
@@ -149,8 +149,8 @@ class InterruptableStoppingCriteria extends StoppingCriteria {
   }
 }
 
-export class TransformersJSLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = "v3";
+export class TransformersJSLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = "v4";
   readonly modelId: TransformersJSModelId;
   readonly provider = "transformers-js";
 
@@ -377,14 +377,14 @@ export class TransformersJSLanguageModel implements LanguageModelV3 {
     tools,
     toolChoice,
     providerOptions,
-  }: Parameters<LanguageModelV3["doGenerate"]>[0]): {
+  }: Parameters<LanguageModelV4["doGenerate"]>[0]): {
     messages: TransformersMessage[];
-    warnings: SharedV3Warning[];
+    warnings: SharedV4Warning[];
     generationOptions: GenerationOptions;
     functionTools: ToolDefinition[];
     enableThinking: boolean;
   } {
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
     // Filter and warn about unsupported tools
     const functionTools: ToolDefinition[] = (tools ?? [])
       .filter(isFunctionTool)
@@ -395,7 +395,7 @@ export class TransformersJSLanguageModel implements LanguageModelV3 {
       }));
 
     const unsupportedTools = (tools ?? []).filter(
-      (tool): tool is LanguageModelV3ProviderTool => !isFunctionTool(tool),
+      (tool): tool is LanguageModelV4ProviderTool => !isFunctionTool(tool),
     );
 
     for (const tool of unsupportedTools) {
@@ -537,8 +537,8 @@ export class TransformersJSLanguageModel implements LanguageModelV3 {
    * Generates a complete text response using TransformersJS
    */
   public async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const {
       messages,
       warnings,
@@ -602,7 +602,7 @@ export class TransformersJSLanguageModel implements LanguageModelV3 {
 
       if (toolCalls.length > 0) {
         const toolCallsToEmit = toolCalls.slice(0, 1);
-        const parts: LanguageModelV3Content[] = [];
+        const parts: LanguageModelV4Content[] = [];
 
         if (textContent) {
           parts.push({
@@ -641,7 +641,7 @@ export class TransformersJSLanguageModel implements LanguageModelV3 {
         };
       }
 
-      const content: LanguageModelV3Content[] = [
+      const content: LanguageModelV4Content[] = [
         {
           type: "text",
           text: textContent || generatedText,
@@ -737,8 +737,8 @@ export class TransformersJSLanguageModel implements LanguageModelV3 {
    * Generates a streaming text response using TransformersJS
    */
   public async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const {
       messages,
       warnings,
@@ -757,7 +757,7 @@ export class TransformersJSLanguageModel implements LanguageModelV3 {
     const self = this;
     const textId = "text-0";
 
-    const stream = new ReadableStream<LanguageModelV3StreamPart>({
+    const stream = new ReadableStream<LanguageModelV4StreamPart>({
       async start(controller) {
         controller.enqueue({ type: "stream-start", warnings });
 
@@ -819,7 +819,7 @@ export class TransformersJSLanguageModel implements LanguageModelV3 {
             controller.enqueue({ type: "text-end", id: textId });
           }
 
-          const finishReason: LanguageModelV3FinishReason =
+          const finishReason: LanguageModelV4FinishReason =
             result.toolCallDetected
               ? { unified: "tool-calls", raw: "tool-calls" }
               : { unified: "stop", raw: "stop" };

--- a/packages/vercel/transformers-js/src/embedding/transformers-js-embedding-model.ts
+++ b/packages/vercel/transformers-js/src/embedding/transformers-js-embedding-model.ts
@@ -1,9 +1,9 @@
 import {
-  EmbeddingModelV3,
+  EmbeddingModelV4,
   TooManyEmbeddingValuesForCallError,
   LoadSettingError,
-  EmbeddingModelV3CallOptions,
-  EmbeddingModelV3Result,
+  EmbeddingModelV4CallOptions,
+  EmbeddingModelV4Result,
 } from "@ai-sdk/provider";
 import {
   pipeline,
@@ -61,8 +61,8 @@ export interface TransformersJSEmbeddingSettings extends Pick<
   maxTokens?: number;
 }
 
-export class TransformersJSEmbeddingModel implements EmbeddingModelV3 {
-  readonly specificationVersion = "v3";
+export class TransformersJSEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = "v4";
   readonly provider = "transformers-js";
   readonly modelId: TransformersJSEmbeddingModelId;
   readonly maxEmbeddingsPerCall = 100; // Reasonable limit for browser
@@ -295,8 +295,8 @@ export class TransformersJSEmbeddingModel implements EmbeddingModelV3 {
   }
 
   async doEmbed(
-    options: EmbeddingModelV3CallOptions,
-  ): Promise<EmbeddingModelV3Result> {
+    options: EmbeddingModelV4CallOptions,
+  ): Promise<EmbeddingModelV4Result> {
     const { values } = options;
 
     if (values.length > this.maxEmbeddingsPerCall) {

--- a/packages/vercel/transformers-js/src/transcription/transformers-js-transcription-model.ts
+++ b/packages/vercel/transformers-js/src/transcription/transformers-js-transcription-model.ts
@@ -1,7 +1,7 @@
 import {
-  TranscriptionModelV3,
-  TranscriptionModelV3CallOptions,
-  SharedV3Warning,
+  TranscriptionModelV4,
+  TranscriptionModelV4CallOptions,
+  SharedV4Warning,
   LoadSettingError,
 } from "@ai-sdk/provider";
 import {
@@ -76,8 +76,8 @@ type TranscriptionModelInstance = [
   PreTrainedModel,
 ];
 
-export class TransformersJSTranscriptionModel implements TranscriptionModelV3 {
-  readonly specificationVersion = "v3";
+export class TransformersJSTranscriptionModel implements TranscriptionModelV4 {
+  readonly specificationVersion = "v4";
   readonly provider = "transformers-js";
   readonly modelId: TransformersJSTranscriptionModelId;
 
@@ -310,8 +310,8 @@ export class TransformersJSTranscriptionModel implements TranscriptionModelV3 {
     });
   }
 
-  private getArgs({ audio, providerOptions }: TranscriptionModelV3CallOptions) {
-    const warnings: SharedV3Warning[] = [];
+  private getArgs({ audio, providerOptions }: TranscriptionModelV4CallOptions) {
+    const warnings: SharedV4Warning[] = [];
 
     const transformersJSOptions = providerOptions?.["transformers-js"];
 
@@ -382,8 +382,8 @@ export class TransformersJSTranscriptionModel implements TranscriptionModelV3 {
   }
 
   async doGenerate(
-    options: TranscriptionModelV3CallOptions,
-  ): Promise<Awaited<ReturnType<TranscriptionModelV3["doGenerate"]>>> {
+    options: TranscriptionModelV4CallOptions,
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4["doGenerate"]>>> {
     const currentDate = new Date();
     const { audio, language, returnTimestamps, maxNewTokens, warnings } =
       this.getArgs(options);
@@ -451,10 +451,10 @@ export class TransformersJSTranscriptionModel implements TranscriptionModelV3 {
     language: string | undefined,
     returnTimestamps: boolean | undefined,
     maxNewTokens: number | undefined,
-    warnings: SharedV3Warning[],
+    warnings: SharedV4Warning[],
     currentDate: Date,
-    options: TranscriptionModelV3CallOptions,
-  ): Promise<Awaited<ReturnType<TranscriptionModelV3["doGenerate"]>>> {
+    options: TranscriptionModelV4CallOptions,
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4["doGenerate"]>>> {
     const worker = this.config.worker!;
 
     await this.initializeWorker();

--- a/packages/vercel/transformers-js/src/transformers-js-provider.ts
+++ b/packages/vercel/transformers-js/src/transformers-js-provider.ts
@@ -1,9 +1,9 @@
 import {
-  EmbeddingModelV3,
-  LanguageModelV3,
+  EmbeddingModelV4,
+  LanguageModelV4,
   NoSuchModelError,
-  ProviderV3,
-  TranscriptionModelV3,
+  ProviderV4,
+  TranscriptionModelV4,
 } from "@ai-sdk/provider";
 import {
   TransformersJSLanguageModel,
@@ -22,7 +22,7 @@ import {
   TransformersJSTranscriptionSettings,
 } from "./transcription/transformers-js-transcription-model";
 
-export interface TransformersJSProvider extends ProviderV3 {
+export interface TransformersJSProvider extends ProviderV4 {
   (
     modelId: TransformersJSModelId,
     settings?: TransformersJSModelSettings,
@@ -47,22 +47,22 @@ export interface TransformersJSProvider extends ProviderV3 {
   embedding(
     modelId: TransformersJSEmbeddingModelId,
     settings?: TransformersJSEmbeddingSettings,
-  ): EmbeddingModelV3;
+  ): EmbeddingModelV4;
 
   embeddingModel: (
     modelId: TransformersJSEmbeddingModelId,
     settings?: TransformersJSEmbeddingSettings,
-  ) => EmbeddingModelV3;
+  ) => EmbeddingModelV4;
 
   transcription(
     modelId: TransformersJSTranscriptionModelId,
     settings?: TransformersJSTranscriptionSettings,
-  ): TranscriptionModelV3;
+  ): TranscriptionModelV4;
 
   transcriptionModel: (
     modelId: TransformersJSTranscriptionModelId,
     settings?: TransformersJSTranscriptionSettings,
-  ) => TranscriptionModelV3;
+  ) => TranscriptionModelV4;
 }
 
 export interface TransformersJSProviderSettings {
@@ -138,7 +138,7 @@ export function createTransformersJS(
     return createChatModel(modelId, settings);
   };
 
-  provider.specificationVersion = "v3" as const;
+  provider.specificationVersion = "v4" as const;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
   provider.embedding = createEmbeddingModel;

--- a/packages/vercel/transformers-js/src/utils/convert-to-transformers-message.ts
+++ b/packages/vercel/transformers-js/src/utils/convert-to-transformers-message.ts
@@ -1,5 +1,6 @@
 import {
-  LanguageModelV3Prompt,
+  LanguageModelV4Prompt,
+  SharedV4FileData,
   UnsupportedFunctionalityError,
 } from "@ai-sdk/provider";
 
@@ -7,38 +8,21 @@ function uint8ArrayToBase64(uint8array: Uint8Array): string {
   return btoa(String.fromCharCode(...uint8array));
 }
 
-function convertDataToURL(
-  data:
-    | string
-    | Buffer
-    | URL
-    | Uint8Array
-    | ArrayBuffer
-    | ReadableStream
-    | undefined,
-  mediaType: string,
-): string {
-  if (data instanceof URL) return data.toString();
+function convertDataToURL(data: SharedV4FileData, mediaType: string): string {
+  switch (data.type) {
+    case "url":
+      return data.url.toString();
 
-  if (typeof data === "string") {
-    return `data:${mediaType};base64,${data}`;
+    case "data":
+      return data.data instanceof Uint8Array
+        ? `data:${mediaType};base64,${uint8ArrayToBase64(data.data)}`
+        : `data:${mediaType};base64,${data.data}`;
+
+    default:
+      throw new UnsupportedFunctionalityError({
+        functionality: `file data type: ${data.type}`,
+      });
   }
-
-  if (data instanceof Uint8Array) {
-    return `data:${mediaType};base64,${uint8ArrayToBase64(data)}`;
-  }
-
-  if (data instanceof ArrayBuffer) {
-    return `data:${mediaType};base64,${uint8ArrayToBase64(new Uint8Array(data))}`;
-  }
-
-  if (typeof Buffer !== "undefined" && data instanceof Buffer) {
-    return `data:${mediaType};base64,${data.toString("base64")}`;
-  }
-
-  throw new UnsupportedFunctionalityError({
-    functionality: `file data type: ${typeof data}`,
-  });
 }
 
 /**
@@ -117,7 +101,7 @@ function processVisionContent(
 }
 
 export function convertToTransformersMessages(
-  prompt: LanguageModelV3Prompt,
+  prompt: LanguageModelV4Prompt,
   isVisionModel: boolean = false,
 ): TransformersMessage[] {
   return prompt.flatMap(

--- a/packages/vercel/transformers-js/src/utils/convert-tools.ts
+++ b/packages/vercel/transformers-js/src/utils/convert-tools.ts
@@ -1,6 +1,6 @@
 import type {
   JSONSchema7,
-  LanguageModelV3FunctionTool,
+  LanguageModelV4FunctionTool,
 } from "@ai-sdk/provider";
 import type { ToolDefinition } from "@browser-ai/shared";
 
@@ -25,7 +25,7 @@ export interface HuggingFaceToolDefinition {
  * @returns Array of HuggingFace-formatted tool definitions
  */
 export function convertToolsToHuggingFaceFormat(
-  tools: Array<LanguageModelV3FunctionTool | ToolDefinition>,
+  tools: Array<LanguageModelV4FunctionTool | ToolDefinition>,
 ): HuggingFaceToolDefinition[] {
   return tools.map((tool) => {
     const parameters =

--- a/packages/vercel/transformers-js/test/convert-to-transformers-message.test.ts
+++ b/packages/vercel/transformers-js/test/convert-to-transformers-message.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect } from "vitest";
 import { convertToTransformersMessages } from "../src/utils/convert-to-transformers-message";
 import {
   UnsupportedFunctionalityError,
-  type LanguageModelV3Prompt,
+  type LanguageModelV4Prompt,
 } from "@ai-sdk/provider";
 
 describe("convertToTransformersMessages", () => {
   it("converts simple text user message", () => {
-    const prompt: LanguageModelV3Prompt = [
+    const prompt: LanguageModelV4Prompt = [
       { role: "user", content: [{ type: "text", text: "Hello" }] },
     ];
 
@@ -16,7 +16,7 @@ describe("convertToTransformersMessages", () => {
   });
 
   it("converts assistant text message", () => {
-    const prompt: LanguageModelV3Prompt = [
+    const prompt: LanguageModelV4Prompt = [
       { role: "assistant", content: [{ type: "text", text: "Hi" }] },
     ];
 
@@ -25,7 +25,7 @@ describe("convertToTransformersMessages", () => {
   });
 
   it("keeps system content as-is", () => {
-    const prompt: LanguageModelV3Prompt = [
+    const prompt: LanguageModelV4Prompt = [
       { role: "system", content: "You are helpful." },
     ];
 
@@ -34,12 +34,12 @@ describe("convertToTransformersMessages", () => {
   });
 
   it("throws for non-vision file input in user message", () => {
-    const prompt: LanguageModelV3Prompt = [
+    const prompt: LanguageModelV4Prompt = [
       {
         role: "user",
         content: [
           { type: "text", text: "See this" },
-          { type: "file", mediaType: "image/png", data: "AAA" },
+          { type: "file", mediaType: "image/png", data: { type: "data", data: "AAA" } },
         ],
       },
     ];
@@ -50,12 +50,12 @@ describe("convertToTransformersMessages", () => {
 
   it("converts image content when isVisionModel=true", () => {
     const base64 = "SGVsbG8="; // Hello
-    const prompt: LanguageModelV3Prompt = [
+    const prompt: LanguageModelV4Prompt = [
       {
         role: "user",
         content: [
           { type: "text", text: "What is in this image?" },
-          { type: "file", mediaType: "image/png", data: base64 },
+          { type: "file", mediaType: "image/png", data: { type: "data", data: base64 } },
           { type: "text", text: "Thanks" },
         ],
       },
@@ -99,7 +99,7 @@ describe("convertToTransformersMessages", () => {
   });
 
   it("converts assistant tool-call content to native HF format", () => {
-    const prompt: LanguageModelV3Prompt = [
+    const prompt: LanguageModelV4Prompt = [
       {
         role: "assistant",
         content: [
@@ -129,7 +129,7 @@ describe("convertToTransformersMessages", () => {
   });
 
   it("converts assistant with both text and tool-call", () => {
-    const prompt: LanguageModelV3Prompt = [
+    const prompt: LanguageModelV4Prompt = [
       {
         role: "assistant",
         content: [

--- a/packages/vercel/transformers-js/test/convert-to-transformers-message.test.ts
+++ b/packages/vercel/transformers-js/test/convert-to-transformers-message.test.ts
@@ -39,7 +39,11 @@ describe("convertToTransformersMessages", () => {
         role: "user",
         content: [
           { type: "text", text: "See this" },
-          { type: "file", mediaType: "image/png", data: { type: "data", data: "AAA" } },
+          {
+            type: "file",
+            mediaType: "image/png",
+            data: { type: "data", data: "AAA" },
+          },
         ],
       },
     ];
@@ -55,7 +59,11 @@ describe("convertToTransformersMessages", () => {
         role: "user",
         content: [
           { type: "text", text: "What is in this image?" },
-          { type: "file", mediaType: "image/png", data: { type: "data", data: base64 } },
+          {
+            type: "file",
+            mediaType: "image/png",
+            data: { type: "data", data: base64 },
+          },
           { type: "text", text: "Thanks" },
         ],
       },

--- a/packages/vercel/transformers-js/test/transformers-js-language-model.test.ts
+++ b/packages/vercel/transformers-js/test/transformers-js-language-model.test.ts
@@ -133,10 +133,8 @@ describe("TransformersJSLanguageModel", () => {
 
     const { text } = await generateText({
       model,
-      messages: [
-        { role: "system", content: "You are a helpful assistant." },
-        { role: "user", content: "Who are you?" },
-      ],
+      instructions: "You are a helpful assistant.",
+      messages: [{ role: "user", content: "Who are you?" }],
     });
 
     expect(text).toBe("I am a helpful assistant.");

--- a/packages/vercel/web-llm/README.md
+++ b/packages/vercel/web-llm/README.md
@@ -26,7 +26,7 @@ The `@browser-ai/web-llm` package is the AI SDK provider for open-source built-i
 
 ## Documentation
 
-For a complete documentation including examples, refer to [this](https://www.browser-ai.dev/docs/ai-sdk-v6/web-llm) site.
+For a complete documentation including examples, refer to [this](https://www.browser-ai.dev/docs/ai-sdk-v7/web-llm) site.
 
 ## Author
 

--- a/packages/vercel/web-llm/package.json
+++ b/packages/vercel/web-llm/package.json
@@ -53,7 +53,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@mlc-ai/web-llm": "^0.2.79",
-    "ai": "^6.0.0"
+    "ai": "^7.0.0"
   },
   "devDependencies": {
     "@browser-ai/shared": "*",

--- a/packages/vercel/web-llm/src/chat/web-llm-language-model.ts
+++ b/packages/vercel/web-llm/src/chat/web-llm-language-model.ts
@@ -1,15 +1,15 @@
 import {
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  SharedV3Warning,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3ProviderTool,
-  LanguageModelV3StreamPart,
-  LanguageModelV3ToolCall,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  SharedV4Warning,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4ProviderTool,
+  LanguageModelV4StreamPart,
+  LanguageModelV4ToolCall,
   LoadSettingError,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamResult,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamResult,
 } from "@ai-sdk/provider";
 import { convertToWebLLMMessages } from "../utils/convert-to-webllm-messages";
 
@@ -76,8 +76,8 @@ type WebLLMConfig = {
   options: WebLLMSettings;
 };
 
-export class WebLLMLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = "v3";
+export class WebLLMLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = "v4";
   readonly modelId: WebLLMModelId;
   readonly provider = "web-llm";
 
@@ -194,8 +194,8 @@ export class WebLLMLanguageModel implements LanguageModelV3 {
     tools,
     toolChoice,
     providerOptions,
-  }: Parameters<LanguageModelV3["doGenerate"]>[0]) {
-    const warnings: SharedV3Warning[] = [];
+  }: Parameters<LanguageModelV4["doGenerate"]>[0]) {
+    const warnings: SharedV4Warning[] = [];
 
     const functionTools: ToolDefinition[] = (tools ?? [])
       .filter(isFunctionTool)
@@ -206,7 +206,7 @@ export class WebLLMLanguageModel implements LanguageModelV3 {
       }));
 
     const unsupportedTools = (tools ?? []).filter(
-      (tool): tool is LanguageModelV3ProviderTool => !isFunctionTool(tool),
+      (tool): tool is LanguageModelV4ProviderTool => !isFunctionTool(tool),
     );
 
     for (const tool of unsupportedTools) {
@@ -315,8 +315,8 @@ export class WebLLMLanguageModel implements LanguageModelV3 {
    * @throws {UnsupportedFunctionalityError} When unsupported features like file input are used
    */
   public async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const converted = this.getArgs(options);
     const { messages, warnings, requestOptions, functionTools } = converted;
 
@@ -372,7 +372,7 @@ export class WebLLMLanguageModel implements LanguageModelV3 {
       if (toolCalls.length > 0) {
         const toolCallsToEmit = toolCalls.slice(0, 1);
 
-        const parts: LanguageModelV3Content[] = [];
+        const parts: LanguageModelV4Content[] = [];
 
         if (textContent) {
           parts.push({
@@ -387,7 +387,7 @@ export class WebLLMLanguageModel implements LanguageModelV3 {
             toolCallId: call.toolCallId,
             toolName: call.toolName,
             input: JSON.stringify(call.args ?? {}),
-          } satisfies LanguageModelV3ToolCall);
+          } satisfies LanguageModelV4ToolCall);
         }
 
         return {
@@ -411,14 +411,14 @@ export class WebLLMLanguageModel implements LanguageModelV3 {
         };
       }
 
-      const content: LanguageModelV3Content[] = [
+      const content: LanguageModelV4Content[] = [
         {
           type: "text",
           text: textContent || rawResponse,
         },
       ];
 
-      let finishReason: LanguageModelV3FinishReason = {
+      let finishReason: LanguageModelV4FinishReason = {
         unified: "stop",
         raw: choice.finish_reason,
       };
@@ -518,8 +518,8 @@ export class WebLLMLanguageModel implements LanguageModelV3 {
    * @throws {UnsupportedFunctionalityError} When unsupported features like file input are used
    */
   public async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const converted = this.getArgs(options);
     const { messages, warnings, requestOptions, functionTools } = converted;
 
@@ -556,7 +556,7 @@ export class WebLLMLanguageModel implements LanguageModelV3 {
 
     const textId = "text-0";
 
-    const stream = new ReadableStream<LanguageModelV3StreamPart>({
+    const stream = new ReadableStream<LanguageModelV4StreamPart>({
       async start(controller) {
         controller.enqueue({
           type: "stream-start",
@@ -596,7 +596,7 @@ export class WebLLMLanguageModel implements LanguageModelV3 {
         };
 
         const finishStream = (
-          finishReason: LanguageModelV3FinishReason,
+          finishReason: LanguageModelV4FinishReason,
           usage?: {
             prompt_tokens?: number;
             completion_tokens?: number;
@@ -671,7 +671,7 @@ export class WebLLMLanguageModel implements LanguageModelV3 {
             emitTextDelta(result.trailingText);
           }
 
-          const finishReason: LanguageModelV3FinishReason = isAbort
+          const finishReason: LanguageModelV4FinishReason = isAbort
             ? { unified: "other", raw: "abort" }
             : result.toolCallDetected
               ? { unified: "tool-calls", raw: "tool-calls" }

--- a/packages/vercel/web-llm/src/embedding/web-llm-embedding-model.ts
+++ b/packages/vercel/web-llm/src/embedding/web-llm-embedding-model.ts
@@ -1,7 +1,7 @@
 import {
-  EmbeddingModelV3,
-  EmbeddingModelV3CallOptions,
-  EmbeddingModelV3Result,
+  EmbeddingModelV4,
+  EmbeddingModelV4CallOptions,
+  EmbeddingModelV4Result,
   TooManyEmbeddingValuesForCallError,
   LoadSettingError,
 } from "@ai-sdk/provider";
@@ -51,8 +51,8 @@ type WebLLMEmbeddingConfig = {
   options: WebLLMEmbeddingSettings;
 };
 
-export class WebLLMEmbeddingModel implements EmbeddingModelV3 {
-  readonly specificationVersion = "v3";
+export class WebLLMEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = "v4";
   readonly provider = "web-llm";
   readonly modelId: WebLLMEmbeddingModelId;
   readonly maxEmbeddingsPerCall: number;
@@ -195,8 +195,8 @@ export class WebLLMEmbeddingModel implements EmbeddingModelV3 {
    * Embed texts using the WebLLM embedding model
    */
   public async doEmbed(
-    options: EmbeddingModelV3CallOptions,
-  ): Promise<EmbeddingModelV3Result> {
+    options: EmbeddingModelV4CallOptions,
+  ): Promise<EmbeddingModelV4Result> {
     const { values, abortSignal } = options;
 
     if (values.length > this.maxEmbeddingsPerCall) {

--- a/packages/vercel/web-llm/src/utils/convert-to-webllm-messages.tsx
+++ b/packages/vercel/web-llm/src/utils/convert-to-webllm-messages.tsx
@@ -1,7 +1,8 @@
 import {
-  LanguageModelV3Prompt,
-  LanguageModelV3ToolResultPart,
-  LanguageModelV3ToolResultOutput,
+  LanguageModelV4Prompt,
+  LanguageModelV4ToolResultPart,
+  LanguageModelV4ToolResultOutput,
+  SharedV4FileData,
   UnsupportedFunctionalityError,
 } from "@ai-sdk/provider";
 import * as webllm from "@mlc-ai/web-llm";
@@ -10,7 +11,7 @@ import { formatToolResults, type ToolResult } from "@browser-ai/shared";
 /**
  * Converts the AI SDK ToolResultOutput format to a simple value + error flag
  */
-function convertToolResultOutput(output: LanguageModelV3ToolResultOutput): {
+function convertToolResultOutput(output: LanguageModelV4ToolResultOutput): {
   value: unknown;
   isError: boolean;
 } {
@@ -37,7 +38,7 @@ function convertToolResultOutput(output: LanguageModelV3ToolResultOutput): {
 /**
  * Converts a ToolResultPart to our internal ToolResult format
  */
-function toToolResult(part: LanguageModelV3ToolResultPart): ToolResult {
+function toToolResult(part: LanguageModelV4ToolResultPart): ToolResult {
   const { value, isError } = convertToolResultOutput(part.output);
   return {
     toolCallId: part.toolCallId,
@@ -54,47 +55,26 @@ function uint8ArrayToBase64(uint8array: Uint8Array): string {
   return btoa(binary);
 }
 
-function convertDataToURL(
-  data:
-    | string
-    | Buffer
-    | URL
-    | Uint8Array
-    | ArrayBuffer
-    | ReadableStream
-    | undefined,
-  mediaType: string,
-): string {
-  if (data instanceof URL) {
-    return data.toString();
-  }
+function convertDataToURL(data: SharedV4FileData, mediaType: string): string {
+  switch (data.type) {
+    case "url":
+      return data.url.toString();
 
-  if (typeof data === "string") {
-    // AI SDK provides base64 string
-    return `data:${mediaType};base64,${data}`;
-  }
+    case "data":
+      return data.data instanceof Uint8Array
+        ? `data:${mediaType};base64,${uint8ArrayToBase64(data.data)}`
+        : // AI SDK provides base64 string
+          `data:${mediaType};base64,${data.data}`;
 
-  if (data instanceof Uint8Array) {
-    return `data:${mediaType};base64,${uint8ArrayToBase64(data)}`;
+    default:
+      throw new UnsupportedFunctionalityError({
+        functionality: `file data type: ${data.type}`,
+      });
   }
-
-  if (data instanceof ArrayBuffer) {
-    return `data:${mediaType};base64,${uint8ArrayToBase64(
-      new Uint8Array(data),
-    )}`;
-  }
-
-  if (typeof Buffer !== "undefined" && data instanceof Buffer) {
-    return `data:${mediaType};base64,${data.toString("base64")}`;
-  }
-
-  throw new UnsupportedFunctionalityError({
-    functionality: `file data type: ${typeof data}`,
-  });
 }
 
 export function convertToWebLLMMessages(
-  prompt: LanguageModelV3Prompt,
+  prompt: LanguageModelV4Prompt,
 ): webllm.ChatCompletionMessageParam[] {
   const messages: webllm.ChatCompletionMessageParam[] = [];
 

--- a/packages/vercel/web-llm/src/web-llm-provider.ts
+++ b/packages/vercel/web-llm/src/web-llm-provider.ts
@@ -1,7 +1,7 @@
 import {
-  EmbeddingModelV3,
+  EmbeddingModelV4,
   NoSuchModelError,
-  ProviderV3,
+  ProviderV4,
 } from "@ai-sdk/provider";
 import {
   WebLLMLanguageModel,
@@ -14,7 +14,7 @@ import {
   WebLLMEmbeddingSettings,
 } from "./embedding/web-llm-embedding-model";
 
-export interface WebLLMProvider extends ProviderV3 {
+export interface WebLLMProvider extends ProviderV4 {
   (modelId: WebLLMModelId, settings?: WebLLMSettings): WebLLMLanguageModel;
 
   /**
@@ -36,7 +36,7 @@ export interface WebLLMProvider extends ProviderV3 {
   embedding(
     modelId: WebLLMEmbeddingModelId,
     settings?: WebLLMEmbeddingSettings,
-  ): EmbeddingModelV3;
+  ): EmbeddingModelV4;
 
   /**
    * Creates a model for text embeddings.
@@ -44,7 +44,7 @@ export interface WebLLMProvider extends ProviderV3 {
   embeddingModel: (
     modelId: WebLLMEmbeddingModelId,
     settings?: WebLLMEmbeddingSettings,
-  ) => EmbeddingModelV3;
+  ) => EmbeddingModelV4;
 }
 
 /**
@@ -78,7 +78,7 @@ export function createWebLLM(): WebLLMProvider {
     return createLanguageModel(modelId, settings);
   };
 
-  provider.specificationVersion = "v3" as const;
+  provider.specificationVersion = "v4" as const;
   provider.languageModel = createLanguageModel;
   provider.chat = createLanguageModel;
   provider.embedding = createEmbeddingModel;

--- a/packages/vercel/web-llm/test/convert-to-webllm-messages.test.ts
+++ b/packages/vercel/web-llm/test/convert-to-webllm-messages.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { convertToWebLLMMessages } from "../src/utils/convert-to-webllm-messages";
 import {
-  LanguageModelV3Prompt,
+  LanguageModelV4Prompt,
   UnsupportedFunctionalityError,
 } from "@ai-sdk/provider";
 
 describe("convertToWebLLMMessages", () => {
   describe("text messages", () => {
     it("should convert simple text user message", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [{ type: "text", text: "Hello, world!" }],
@@ -26,7 +26,7 @@ describe("convertToWebLLMMessages", () => {
     });
 
     it("should convert system message", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "system",
           content: "You are a helpful assistant.",
@@ -44,7 +44,7 @@ describe("convertToWebLLMMessages", () => {
     });
 
     it("should convert assistant message", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "assistant",
           content: [{ type: "text", text: "Hi there!" }],
@@ -62,7 +62,7 @@ describe("convertToWebLLMMessages", () => {
     });
 
     it("should handle conversation with multiple message types", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "system",
           content: "You are helpful.",
@@ -90,7 +90,7 @@ describe("convertToWebLLMMessages", () => {
   describe("image file conversion", () => {
     it("should convert base64 image data to data URL", () => {
       const base64Data = "SGVsbG8gV29ybGQ="; // "Hello World" in base64
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
@@ -98,7 +98,7 @@ describe("convertToWebLLMMessages", () => {
             {
               type: "file",
               mediaType: "image/png",
-              data: base64Data,
+              data: { type: "data", data: base64Data },
             },
           ],
         },
@@ -122,7 +122,7 @@ describe("convertToWebLLMMessages", () => {
     });
 
     it("should handle mixed text and image content", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
@@ -130,7 +130,7 @@ describe("convertToWebLLMMessages", () => {
             {
               type: "file",
               mediaType: "image/png",
-              data: "aGVsbG8=", // "hello" in base64
+              data: { type: "data", data: "aGVsbG8=" }, // "hello" in base64
             },
             { type: "text", text: "What do you see?" },
           ],
@@ -157,14 +157,14 @@ describe("convertToWebLLMMessages", () => {
 
   describe("error handling", () => {
     it("should throw for non-image file types", () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: "user",
           content: [
             {
               type: "file",
               mediaType: "audio/mp3",
-              data: "some data",
+              data: { type: "data", data: "some data" },
             },
           ],
         },

--- a/packages/vercel/web-llm/test/web-llm-embedding-model.test.ts
+++ b/packages/vercel/web-llm/test/web-llm-embedding-model.test.ts
@@ -57,7 +57,7 @@ describe("WebLLMEmbeddingModel", () => {
       expect(model).toBeInstanceOf(WebLLMEmbeddingModel);
       expect(model.modelId).toBe("test-model");
       expect(model.provider).toBe("web-llm");
-      expect(model.specificationVersion).toBe("v3");
+      expect(model.specificationVersion).toBe("v4");
       expect(model.supportsParallelCalls).toBe(false);
       expect(model.maxEmbeddingsPerCall).toBe(100);
     });

--- a/packages/vercel/web-llm/test/web-llm-language-model.test.ts
+++ b/packages/vercel/web-llm/test/web-llm-language-model.test.ts
@@ -59,7 +59,7 @@ describe("WebLLMLanguageModel", () => {
       );
 
       expect(model).toBeInstanceOf(WebLLMLanguageModel);
-      expect(model.specificationVersion).toBe("v3");
+      expect(model.specificationVersion).toBe("v4");
       expect(model.provider).toBe("web-llm");
       expect(model.modelId).toBe("Llama-3.1-8B-Instruct-q4f32_1-MLC");
     });


### PR DESCRIPTION
Migrates all four `packages/vercel` packages and the `next-hybrid` example to AI SDK v7, which introduces the v4 provider specification.

All models and providers now implement the v4 spec (`specificationVersion: "v4"`, `ProviderV4`, `LanguageModelV4*`, `EmbeddingModelV4*`, `TranscriptionModelV4*`, `SharedV4Warning`).

Key behavioral change: file part `data` is now a tagged discriminated union (`SharedV4FileData`) instead of `string | Uint8Array | URL`. Each package's message converter unwraps it explicitly:

### Tests

Tests updated to v4 fixtures (tagged-union file data, `"v4"` spec assertions) and system messages moved to the new top-level `instructions` option per v7's prompt changes.