### PR TITLE
fix(tool-calling): parse Python-style and delimiter-wrapped tool calls

### DIFF
--- a/.changeset/lfm25-tool-calls.md
+++ b/.changeset/lfm25-tool-calls.md
@@ -1,0 +1,16 @@
+---
+"@browser-ai/transformers-js": patch
+"@browser-ai/web-llm": patch
+"@browser-ai/core": patch
+---
+
+Fix tool call parsing for Python-style and delimiter-wrapped formats.
+
+- Arguments are no longer split on commas inside quoted values, so a call like
+  `search(query="Doe, Jane")` keeps its argument intact.
+- Multiple calls in a single bracket (`[a(...), b(...)]`) are now parsed;
+  previously the whole block was skipped.
+- `<|tool_call_start|>` / `<|tool_call_end|>` delimiters are recognized, so
+  models using them (LFM2.5) no longer leak the markers into response text.
+- transformers-js: tool call arguments are passed to chat templates as a
+  mapping rather than a JSON-encoded string, which some templates reject.

--- a/examples/next-hybrid/app/transformers-js/page.tsx
+++ b/examples/next-hybrid/app/transformers-js/page.tsx
@@ -95,6 +95,7 @@ function TransformersJSChat({
         name,
         supportsWorker,
         enableThinking: _defaultThinking,
+        thinkingPrefilled: _thinkingPrefilled,
         ...modelOptions
       } = modelConfig;
 
@@ -116,6 +117,7 @@ function TransformersJSChat({
   // Sync thinking toggle to transport
   if (chatTransport instanceof TransformersChatTransport) {
     chatTransport.enableThinking = enableThinking;
+    chatTransport.thinkingPrefilled = modelConfig.thinkingPrefilled ?? false;
   }
 
   const {

--- a/examples/next-hybrid/app/transformers-js/util/models-config.ts
+++ b/examples/next-hybrid/app/transformers-js/util/models-config.ts
@@ -5,9 +5,25 @@ export interface ModelConfig extends Omit<WorkerLoadOptions, "modelId"> {
   name: string;
   supportsWorker: boolean;
   enableThinking?: boolean;
+  /**
+   * True when the model's chat template already emits the opening `<think>` tag
+   * as part of the generation prompt, so the model only ever generates the
+   * closing `</think>`. Reasoning extraction has to assume it starts open.
+   */
+  thinkingPrefilled?: boolean;
 }
 
 export const MODELS: ModelConfig[] = [
+  {
+    id: "LiquidAI/LFM2.5-2.6B-ONNX",
+    name: "LFM2.5 2.6B",
+    device: "webgpu",
+    dtype: "q4f16",
+    enableThinking: true,
+    thinkingPrefilled: true,
+    isVisionModel: false,
+    supportsWorker: true,
+  },
   {
     id: "onnx-community/gemma-4-E2B-it-ONNX",
     name: "Gemma4 E2B",

--- a/examples/next-hybrid/app/transformers-js/util/models-config.ts
+++ b/examples/next-hybrid/app/transformers-js/util/models-config.ts
@@ -5,11 +5,6 @@ export interface ModelConfig extends Omit<WorkerLoadOptions, "modelId"> {
   name: string;
   supportsWorker: boolean;
   enableThinking?: boolean;
-  /**
-   * True when the model's chat template already emits the opening `<think>` tag
-   * as part of the generation prompt, so the model only ever generates the
-   * closing `</think>`. Reasoning extraction has to assume it starts open.
-   */
   thinkingPrefilled?: boolean;
 }
 

--- a/examples/next-hybrid/app/transformers-js/util/transformers-chat-transport.ts
+++ b/examples/next-hybrid/app/transformers-js/util/transformers-chat-transport.ts
@@ -84,6 +84,11 @@ export const createTools = () => ({
 export class TransformersChatTransport implements ChatTransport<TransformersUIMessage> {
   private readonly model: TransformersJSLanguageModel;
   public enableThinking = false;
+  /**
+   * Set for models whose chat template pre-fills the opening `<think>` tag, so
+   * the generated text only contains the closing `</think>`.
+   */
+  public thinkingPrefilled = false;
   private tools: ReturnType<typeof createTools>;
 
   constructor(model: TransformersJSLanguageModel) {
@@ -153,6 +158,7 @@ export class TransformersChatTransport implements ChatTransport<TransformersUIMe
             model,
             middleware: extractReasoningMiddleware({
               tagName: "think",
+              startWithReasoning: this.enableThinking && this.thinkingPrefilled,
             }),
           }),
           tools: this.tools,

--- a/packages/vercel/shared/src/streaming/tool-call-detector.ts
+++ b/packages/vercel/shared/src/streaming/tool-call-detector.ts
@@ -72,6 +72,12 @@ export const EXTENDED_FENCE_PATTERNS: FencePattern[] = [
     end: "<tool_call|>",
     reconstructStart: "<|tool_call>",
   },
+  {
+    // LFM2 / LFM2.5
+    start: "<|tool_call_start|>",
+    end: "<|tool_call_end|>",
+    reconstructStart: "<|tool_call_start|>",
+  },
 ];
 
 /**

--- a/packages/vercel/shared/src/tool-calling/parse-json-function-calls.ts
+++ b/packages/vercel/shared/src/tool-calling/parse-json-function-calls.ts
@@ -151,9 +151,7 @@ function buildRegex(options: ParseJsonFunctionCallsOptions): RegExp {
 
   if (options.supportPythonStyle) {
     // One or more `func(args)` calls inside brackets: [f(a="b"), g(c="d")]
-    patterns.push(
-      "\\[\\s*\\w+\\([^)]*\\)(?:\\s*,\\s*\\w+\\([^)]*\\))*\\s*\\]",
-    );
+    patterns.push("\\[\\s*\\w+\\([^)]*\\)(?:\\s*,\\s*\\w+\\([^)]*\\))*\\s*\\]");
   }
 
   if (options.supportCallColonStyle) {

--- a/packages/vercel/shared/src/tool-calling/parse-json-function-calls.ts
+++ b/packages/vercel/shared/src/tool-calling/parse-json-function-calls.ts
@@ -12,6 +12,8 @@ export interface ParseJsonFunctionCallsOptions {
   supportParametersField?: boolean;
   /** Support call:name{key:value} style delimited with <|tool_call>...<tool_call|> */
   supportCallColonStyle?: boolean;
+  /** Support <|tool_call_start|>...<|tool_call_end|> delimiters (LFM2 / LFM2.5) */
+  supportToolCallStartEnd?: boolean;
 }
 
 const DEFAULT_OPTIONS: ParseJsonFunctionCallsOptions = {
@@ -19,6 +21,7 @@ const DEFAULT_OPTIONS: ParseJsonFunctionCallsOptions = {
   supportPythonStyle: true,
   supportParametersField: true,
   supportCallColonStyle: true,
+  supportToolCallStartEnd: true,
 };
 
 function generateToolCallId(): string {
@@ -54,6 +57,88 @@ function parseCallColonParams(params: string): Record<string, unknown> {
   return args;
 }
 
+/**
+ * Splits an argument list on commas that are not inside quotes or brackets,
+ * so values like `query="Doe, Jane"` survive intact.
+ */
+function splitArguments(args: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  let depth = 0;
+
+  for (let i = 0; i < args.length; i++) {
+    const char = args[i];
+
+    if (quote) {
+      if (char === "\\" && i + 1 < args.length) {
+        current += char + args[++i];
+        continue;
+      }
+      if (char === quote) quote = null;
+      current += char;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+    } else if (char === "[" || char === "{" || char === "(") {
+      depth++;
+      current += char;
+    } else if (char === "]" || char === "}" || char === ")") {
+      depth--;
+      current += char;
+    } else if (char === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  if (current.trim()) parts.push(current);
+  return parts.map((part) => part.trim()).filter(Boolean);
+}
+
+/**
+ * Parses Python-style calls such as `func(arg="value")`. Accepts several calls
+ * separated by commas, with or without the surrounding brackets.
+ */
+function parsePythonStyleCalls(text: string): ParsedToolCall[] {
+  const calls: ParsedToolCall[] = [];
+  const callRegex = /(\w+)\(([^)]*)\)/g;
+
+  for (const match of text.matchAll(callRegex)) {
+    const [, funcName, rawArgs] = match;
+    const args: Record<string, unknown> = {};
+
+    for (const pair of splitArguments(rawArgs ?? "")) {
+      const equalIndex = pair.indexOf("=");
+      if (equalIndex <= 0) continue;
+
+      const key = pair.substring(0, equalIndex).trim();
+      let value = pair.substring(equalIndex + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.substring(1, value.length - 1);
+      }
+      args[key] = value;
+    }
+
+    calls.push({
+      type: "tool-call",
+      toolCallId: generateToolCallId(),
+      toolName: funcName,
+      args,
+    });
+  }
+
+  return calls;
+}
+
 function buildRegex(options: ParseJsonFunctionCallsOptions): RegExp {
   const patterns: string[] = [];
 
@@ -65,11 +150,20 @@ function buildRegex(options: ParseJsonFunctionCallsOptions): RegExp {
   }
 
   if (options.supportPythonStyle) {
-    patterns.push("\\[(\\w+)\\(([^)]*)\\)\\]");
+    // One or more `func(args)` calls inside brackets: [f(a="b"), g(c="d")]
+    patterns.push(
+      "\\[\\s*\\w+\\([^)]*\\)(?:\\s*,\\s*\\w+\\([^)]*\\))*\\s*\\]",
+    );
   }
 
   if (options.supportCallColonStyle) {
     patterns.push("<\\|tool_call>\\s*([\\s\\S]*?)\\s*<tool_call\\|>");
+  }
+
+  if (options.supportToolCallStartEnd) {
+    patterns.push(
+      "<\\|tool_call_start\\|>\\s*([\\s\\S]*?)\\s*<\\|tool_call_end\\|>",
+    );
   }
 
   return new RegExp(patterns.join("|"), "gi");
@@ -112,37 +206,11 @@ export function parseJsonFunctionCalls(
     textContent = textContent.replace(fullMatch, "");
 
     try {
-      // Check for Python-style match: [functionName(args)]
-      if (mergedOptions.supportPythonStyle && match[0].startsWith("[")) {
-        const pythonMatch = /\[(\w+)\(([^)]*)\)\]/.exec(match[0]);
-        if (pythonMatch) {
-          const [, funcName, pythonArgs] = pythonMatch;
-          const args: Record<string, unknown> = {};
-
-          if (pythonArgs && pythonArgs.trim()) {
-            const argPairs = pythonArgs.split(",").map((s) => s.trim());
-            for (const pair of argPairs) {
-              const equalIndex = pair.indexOf("=");
-              if (equalIndex > 0) {
-                const key = pair.substring(0, equalIndex).trim();
-                let value = pair.substring(equalIndex + 1).trim();
-                if (
-                  (value.startsWith('"') && value.endsWith('"')) ||
-                  (value.startsWith("'") && value.endsWith("'"))
-                ) {
-                  value = value.substring(1, value.length - 1);
-                }
-                args[key] = value;
-              }
-            }
-          }
-
-          toolCalls.push({
-            type: "tool-call",
-            toolCallId: generateToolCallId(),
-            toolName: funcName,
-            args: args,
-          });
+      // Check for Python-style match: [functionName(args), ...]
+      if (mergedOptions.supportPythonStyle && fullMatch.startsWith("[")) {
+        const pythonCalls = parsePythonStyleCalls(fullMatch);
+        if (pythonCalls.length > 0) {
+          toolCalls.push(...pythonCalls);
           continue;
         }
       }
@@ -167,6 +235,16 @@ export function parseJsonFunctionCalls(
       const trimmed = innerContent.trim();
 
       if (!trimmed) continue;
+
+      // Delimited blocks may wrap Python-style calls rather than JSON
+      // (LFM2/LFM2.5 emit `<|tool_call_start|>[f(a="b")]<|tool_call_end|>`)
+      if (mergedOptions.supportPythonStyle && /^\[?\s*\w+\(/.test(trimmed)) {
+        const pythonCalls = parsePythonStyleCalls(trimmed);
+        if (pythonCalls.length > 0) {
+          toolCalls.push(...pythonCalls);
+          continue;
+        }
+      }
 
       // Try parsing as a single JSON value first (object or array)
       try {

--- a/packages/vercel/shared/test/index.test.ts
+++ b/packages/vercel/shared/test/index.test.ts
@@ -121,6 +121,41 @@ describe("@browser-ai/shared exports", () => {
       expect(result.toolCalls[0].args).toEqual({ query: "hello" });
     });
 
+    it("should parse Python-style arguments containing commas", () => {
+      const result = parseJsonFunctionCalls(
+        '[search(query="Doe, Jane", limit="5")]',
+      );
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].args).toEqual({
+        query: "Doe, Jane",
+        limit: "5",
+      });
+    });
+
+    it("should parse multiple Python-style calls in one bracket", () => {
+      const result = parseJsonFunctionCalls('[a(x="1"), b(y="2")]');
+      expect(result.toolCalls.map((c) => c.toolName)).toEqual(["a", "b"]);
+    });
+
+    it("should parse <|tool_call_start|> delimited calls and strip the delimiters", () => {
+      const result = parseJsonFunctionCalls(
+        'Sure.<|tool_call_start|>[webSearch(query="hello")]<|tool_call_end|>',
+      );
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].toolName).toBe("webSearch");
+      expect(result.toolCalls[0].args).toEqual({ query: "hello" });
+      expect(result.textContent).toBe("Sure.");
+    });
+
+    it("should parse JSON inside <|tool_call_start|> delimiters", () => {
+      const result = parseJsonFunctionCalls(
+        '<|tool_call_start|>{"name": "search", "arguments": {"q": "x"}}<|tool_call_end|>',
+      );
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].toolName).toBe("search");
+      expect(result.toolCalls[0].args).toEqual({ q: "x" });
+    });
+
     it("should parse call:name{} style without parameters", () => {
       const result = parseJsonFunctionCalls(
         "<|tool_call>call:getLocation{}<tool_call|>",
@@ -301,6 +336,31 @@ describe("@browser-ai/shared exports", () => {
         "<|tool_call>call:randomNumber{max:6,min:1}<tool_call|>",
       );
       expect(detector.detectFence().fence).not.toBeNull();
+    });
+
+    it("should detect <|tool_call_start|> fence without leaking delimiters", () => {
+      const detector = createExtendedDetector();
+      detector.addChunk("Sure.<|tool_call_start|>");
+      detector.addChunk('[webSearch(query="hello")]');
+      detector.addChunk("<|tool_call_end|>");
+
+      const start = detector.detectStreamingFence();
+      expect(start.inFence).toBe(true);
+      expect(start.safeContent).toBe("Sure.");
+
+      let completeFence: string | null = null;
+      while (detector.hasContent()) {
+        const result = detector.detectStreamingFence();
+        if (result.completeFence) {
+          completeFence = result.completeFence;
+          break;
+        }
+        if (!result.safeContent) break;
+      }
+
+      expect(completeFence).toBe(
+        '<|tool_call_start|>[webSearch(query="hello")]<|tool_call_end|>',
+      );
     });
   });
 

--- a/packages/vercel/transformers-js/src/utils/convert-to-transformers-message.ts
+++ b/packages/vercel/transformers-js/src/utils/convert-to-transformers-message.ts
@@ -39,7 +39,12 @@ export interface TransformersMessage {
     type: "function";
     function: {
       name: string;
-      arguments: string;
+      /**
+       * A mapping, not a JSON string. HuggingFace chat templates serialize this
+       * themselves (`arguments | tojson`), and some templates (e.g. LFM2.5)
+       * reject a pre-serialized string outright.
+       */
+      arguments: unknown;
     };
   }>;
   tool_call_id?: string;
@@ -146,12 +151,7 @@ export function convertToTransformersMessages(
               type: "function" as const,
               function: {
                 name: (part as any).toolName,
-                arguments:
-                  typeof (part as any).input === "string"
-                    ? (part as any).input
-                    : JSON.stringify(
-                        normalizeToolArguments((part as any).input),
-                      ),
+                arguments: normalizeToolArguments((part as any).input),
               },
             }));
 

--- a/packages/vercel/transformers-js/src/utils/generation-helpers.ts
+++ b/packages/vercel/transformers-js/src/utils/generation-helpers.ts
@@ -27,6 +27,9 @@ export function normalizeStreamedTextChunk(output: string): string | null {
     trimmed === "<|tool_call|>" ||
     trimmed === "<|tool_call>" ||
     trimmed === "<tool_call|>" ||
+    // LFM2 / LFM2.5 delimiters — kept so the fence detector can pair them up
+    trimmed === "<|tool_call_start|>" ||
+    trimmed === "<|tool_call_end|>" ||
     /^<\/?tool_call>$/.test(trimmed);
 
   if (isSpecialToken && !isToolCallToken && !trimmed.includes("channel")) {

--- a/packages/vercel/transformers-js/test/convert-to-transformers-message.test.ts
+++ b/packages/vercel/transformers-js/test/convert-to-transformers-message.test.ts
@@ -131,8 +131,29 @@ describe("convertToTransformersMessages", () => {
       type: "function",
       function: {
         name: "calculate",
-        arguments: '{"x":5,"y":10}',
+        arguments: { x: 5, y: 10 },
       },
+    });
+  });
+
+  it("parses JSON-string tool-call input into a mapping", () => {
+    const prompt: LanguageModelV4Prompt = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call_str",
+            toolName: "calculate",
+            input: '{"x":5,"y":10}',
+          } as any,
+        ],
+      },
+    ];
+    const result = convertToTransformersMessages(prompt);
+    expect(result[0].tool_calls![0].function.arguments).toEqual({
+      x: 5,
+      y: 10,
     });
   });
 


### PR DESCRIPTION
Adds support for `LiquidAI/LFM2.5-2.6B-ONNX`, which exposed three issues:

**Reasoning leaked a stray `</think>`.** LFM2.5's chat template pre-fills the
opening `<think>` into the generation prompt, so the model only ever emits the
closing tag and `extractReasoningMiddleware` never opened a reasoning block.
Added a `thinkingPrefilled` model flag in the example that maps to the
middleware's `startWithReasoning`.

**`<|tool_call_start|>` / `<|tool_call_end|>` leaked into the visible text.**
These delimiters were unknown to the fence detector, and the special-token
filter dropped them before the detector could pair them up. Both now recognize
them, and the parser strips the whole block from text content.

**Tool calls failed on the follow-up turn** with `Tool call arguments must be a
mapping, got a JSON-encoded string`. `convertToTransformersMessages` was
serializing tool-call input before handing it to the chat template; it now
passes a mapping, which is what HuggingFace templates expect.

Also fixes two latent bugs in the Python-style call parser it relies on:
arguments split on every comma (breaking `query="Doe, Jane"`), and only one
call per bracket was matched.

Bumps `core` and `web-llm` alongside `transformers-js` - all three bundle
`@browser-ai/shared` and use the parser, so the parsing fixes ship in each.

Tests added for the delimiters (parser + streaming detector), quoted commas,
multi-call brackets, and mapping-shaped tool arguments.
