### PR TITLE
fix(tool-calling): parse structured values in Python-style tool calls

### DIFF
--- a/.changeset/python-arg-values.md
+++ b/.changeset/python-arg-values.md
@@ -1,0 +1,15 @@
+---
+"@browser-ai/transformers-js": patch
+"@browser-ai/web-llm": patch
+"@browser-ai/core": patch
+---
+
+Parse structured argument values in Python-style tool calls.
+
+Argument values were stored as raw text, so a call like
+`[ask_user(questions=[{'question': 'How many?'}])]` produced a string
+containing Python syntax instead of an array. Values are now parsed as JSON or
+Python literals, covering lists, dicts, numbers, and `True`/`False`/`None`.
+
+Calls whose arguments contain parentheses (`q="budget (roughly)?"`) are also no
+longer truncated at the first `)`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,6 +187,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -530,6 +531,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1160,6 +1162,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1200,6 +1203,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1935,6 +1939,7 @@
       "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.0.1.tgz",
       "integrity": "sha512-tAQYEy+cnW0ku/NxBSjFXCymi+DZa1/JkoGf4McxjzO36CZZIL/J4TF6X7i/tzs75yTjshUDgsvSz03s2xym2A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@huggingface/jinja": "^0.5.6",
         "@huggingface/tokenizers": "^0.1.3",
@@ -6555,6 +6560,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -7588,6 +7594,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7598,6 +7605,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7739,6 +7747,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -8679,6 +8688,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8719,6 +8729,7 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.22.tgz",
       "integrity": "sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "4.0.16",
         "@ai-sdk/provider": "4.0.3",
@@ -9326,6 +9337,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10163,7 +10175,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -10466,6 +10479,7 @@
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10534,6 +10548,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11336,6 +11351,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11747,6 +11763,7 @@
       "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-16.3.2.tgz",
       "integrity": "sha512-lpvW2qnH0C7c1CGCv6Ym1GrDTVyV+APb1h3hBuWcGiAamNN1vw7lldXQVJ5ENL/SJr6TQ6gJ+qHExNohsh/ynA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.7.2",
         "@orama/orama": "^3.1.17",
@@ -12691,6 +12708,7 @@
       "version": "4.12.25",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -13572,6 +13590,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -13620,6 +13639,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -13871,7 +13891,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13893,7 +13912,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13915,7 +13933,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13937,7 +13954,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13959,7 +13975,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13981,7 +13996,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14003,7 +14017,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14025,7 +14038,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14047,7 +14059,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14069,7 +14080,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14091,7 +14101,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14164,7 +14173,6 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
       "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -14231,6 +14239,7 @@
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.561.0.tgz",
       "integrity": "sha512-Y59gMY38tl4/i0qewcqohPdEbieBy7SovpBL9IFebhc2mDd8x4PZSOsiFRkpPcOq6bj1r/mjH/Rk73gSlIJP2A==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -15559,6 +15568,7 @@
       "version": "16.2.6",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
       "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
@@ -16351,6 +16361,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16858,6 +16869,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16867,6 +16879,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16895,6 +16908,7 @@
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
       "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -18655,7 +18669,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -18789,6 +18804,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19228,6 +19244,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19758,6 +19775,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -19849,6 +19867,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "devOptional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20181,6 +20200,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -20248,7 +20268,7 @@
     },
     "packages/vercel/core": {
       "name": "@browser-ai/core",
-      "version": "2.1.13",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@mediapipe/tasks-text": "^0.10.22-rc.20250304"
@@ -20285,6 +20305,7 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -20543,6 +20564,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -20682,6 +20704,7 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -20914,7 +20937,7 @@
     },
     "packages/vercel/transformers-js": {
       "name": "@browser-ai/transformers-js",
-      "version": "2.2.2",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@browser-ai/shared": "*",
@@ -20948,6 +20971,7 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -21206,6 +21230,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -21326,7 +21351,7 @@
     },
     "packages/vercel/web-llm": {
       "name": "@browser-ai/web-llm",
-      "version": "2.1.8",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@browser-ai/shared": "*",
@@ -21361,6 +21386,7 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -21619,6 +21645,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",

--- a/packages/vercel/shared/src/tool-calling/parse-json-function-calls.ts
+++ b/packages/vercel/shared/src/tool-calling/parse-json-function-calls.ts
@@ -58,6 +58,34 @@ function parseCallColonParams(params: string): Record<string, unknown> {
 }
 
 /**
+ * Decides whether the quote at `index` actually terminates the string.
+ *
+ * Models rarely escape apostrophes, so `'What's the budget?'` is common. A
+ * single quote therefore only closes when the next meaningful character is
+ * structural; otherwise it is a literal apostrophe. Double quotes are
+ * unambiguous and always close.
+ */
+function closesQuote(text: string, index: number, quote: string): boolean {
+  if (quote !== "'") return true;
+
+  for (let i = index + 1; i < text.length; i++) {
+    const char = text[i];
+    if (char === " " || char === "\t" || char === "\n" || char === "\r") {
+      continue;
+    }
+    return (
+      char === "," ||
+      char === ":" ||
+      char === "}" ||
+      char === "]" ||
+      char === ")"
+    );
+  }
+
+  return true; // end of input
+}
+
+/**
  * Splits an argument list on commas that are not inside quotes or brackets,
  * so values like `query="Doe, Jane"` survive intact.
  */
@@ -75,7 +103,7 @@ function splitArguments(args: string): string[] {
         current += char + args[++i];
         continue;
       }
-      if (char === quote) quote = null;
+      if (char === quote && closesQuote(args, i, quote)) quote = null;
       current += char;
       continue;
     }
@@ -102,42 +130,184 @@ function splitArguments(args: string): string[] {
 }
 
 /**
+ * Rewrites a Python literal into JSON: single-quoted strings become
+ * double-quoted, and `True`/`False`/`None` become their JSON equivalents.
+ * Tokenizes rather than string-replacing so quotes and keywords appearing
+ * inside string values are left alone.
+ */
+function pythonLiteralToJson(input: string): string {
+  let out = "";
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (char === "'" || char === '"') {
+      const quote = char;
+      let value = "";
+      i++;
+
+      for (
+        ;
+        i < input.length &&
+        !(input[i] === quote && closesQuote(input, i, quote));
+        i++
+      ) {
+        if (input[i] === "\\" && i + 1 < input.length) {
+          // Unescape into the raw value; JSON.stringify re-escapes below
+          const next = input[++i];
+          value +=
+            next === "n"
+              ? "\n"
+              : next === "t"
+                ? "\t"
+                : next === "r"
+                  ? "\r"
+                  : next;
+          continue;
+        }
+        value += input[i];
+      }
+
+      out += JSON.stringify(value);
+      continue;
+    }
+
+    if (/[A-Za-z]/.test(char)) {
+      let word = "";
+      while (i < input.length && /[A-Za-z]/.test(input[i])) word += input[i++];
+      i--;
+
+      out +=
+        word === "True"
+          ? "true"
+          : word === "False"
+            ? "false"
+            : word === "None"
+              ? "null"
+              : word;
+      continue;
+    }
+
+    out += char;
+  }
+
+  return out;
+}
+
+/**
+ * Parses a single Python-style argument value into its JavaScript equivalent.
+ * Handles JSON, Python literals (lists, dicts, `True`/`None`), numbers, and
+ * quoted strings; anything unrecognized is returned as a trimmed string.
+ */
+function parsePythonValue(raw: string): unknown {
+  const value = raw.trim();
+  if (!value) return "";
+
+  const isQuoted =
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"));
+
+  // Structured or scalar literals — try JSON first, then Python syntax
+  if (!isQuoted) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      // not JSON, fall through
+    }
+
+    try {
+      return JSON.parse(pythonLiteralToJson(value));
+    } catch {
+      return value;
+    }
+  }
+
+  // Quoted string: reuse the same tokenizer so escapes are handled
+  try {
+    return JSON.parse(pythonLiteralToJson(value));
+  } catch {
+    return value.substring(1, value.length - 1);
+  }
+}
+
+/**
+ * Finds `name(...)` calls in text, tracking quotes and nesting so arguments
+ * containing parentheses (e.g. `q="budget (roughly)?"`) are not truncated.
+ */
+function scanPythonCalls(text: string): Array<{ name: string; args: string }> {
+  const calls: Array<{ name: string; args: string }> = [];
+  const nameRegex = /(\w+)\s*\(/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = nameRegex.exec(text)) !== null) {
+    const start = match.index + match[0].length;
+    let depth = 1;
+    let quote: string | null = null;
+    let i = start;
+
+    for (; i < text.length && depth > 0; i++) {
+      const char = text[i];
+
+      if (quote) {
+        if (char === "\\") i++;
+        else if (char === quote && closesQuote(text, i, quote)) quote = null;
+        continue;
+      }
+
+      if (char === '"' || char === "'") quote = char;
+      else if (char === "(") depth++;
+      else if (char === ")") depth--;
+    }
+
+    // Unbalanced — no closing paren, so this is not a complete call
+    if (depth !== 0) continue;
+
+    calls.push({ name: match[1], args: text.slice(start, i - 1) });
+    nameRegex.lastIndex = i;
+  }
+
+  return calls;
+}
+
+/**
  * Parses Python-style calls such as `func(arg="value")`. Accepts several calls
  * separated by commas, with or without the surrounding brackets.
  */
 function parsePythonStyleCalls(text: string): ParsedToolCall[] {
   const calls: ParsedToolCall[] = [];
-  const callRegex = /(\w+)\(([^)]*)\)/g;
 
-  for (const match of text.matchAll(callRegex)) {
-    const [, funcName, rawArgs] = match;
+  for (const { name, args: rawArgs } of scanPythonCalls(text)) {
     const args: Record<string, unknown> = {};
 
-    for (const pair of splitArguments(rawArgs ?? "")) {
+    for (const pair of splitArguments(rawArgs)) {
       const equalIndex = pair.indexOf("=");
       if (equalIndex <= 0) continue;
 
       const key = pair.substring(0, equalIndex).trim();
-      let value = pair.substring(equalIndex + 1).trim();
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.substring(1, value.length - 1);
-      }
-      args[key] = value;
+      args[key] = parsePythonValue(pair.substring(equalIndex + 1));
     }
 
     calls.push({
       type: "tool-call",
       toolCallId: generateToolCallId(),
-      toolName: funcName,
+      toolName: name,
       args,
     });
   }
 
   return calls;
 }
+
+/**
+ * A quoted string, either single or double, with escapes. An unescaped `'` is
+ * treated as content unless followed by a structural character, mirroring
+ * `closesQuote` so detection agrees with tokenization.
+ */
+const QUOTED = `"(?:[^"\\\\]|\\\\.)*"|'(?:[^'\\\\]|\\\\.|'(?!\\s*(?:[,:}\\])]|$)))*'`;
+/** Argument list body: bare chars, quoted strings, or one level of nesting */
+const CALL_ARGS = `(?:[^()"']|${QUOTED}|\\((?:[^()"']|${QUOTED})*\\))*`;
+/** A single Python-style call: `name(args)` */
+const PY_CALL = `\\w+\\(${CALL_ARGS}\\)`;
 
 function buildRegex(options: ParseJsonFunctionCallsOptions): RegExp {
   const patterns: string[] = [];
@@ -151,7 +321,7 @@ function buildRegex(options: ParseJsonFunctionCallsOptions): RegExp {
 
   if (options.supportPythonStyle) {
     // One or more `func(args)` calls inside brackets: [f(a="b"), g(c="d")]
-    patterns.push("\\[\\s*\\w+\\([^)]*\\)(?:\\s*,\\s*\\w+\\([^)]*\\))*\\s*\\]");
+    patterns.push(`\\[\\s*${PY_CALL}(?:\\s*,\\s*${PY_CALL})*\\s*\\]`);
   }
 
   if (options.supportCallColonStyle) {

--- a/packages/vercel/shared/test/index.test.ts
+++ b/packages/vercel/shared/test/index.test.ts
@@ -132,6 +132,81 @@ describe("@browser-ai/shared exports", () => {
       });
     });
 
+    it("should parse Python-style list and dict argument values", () => {
+      const result = parseJsonFunctionCalls(
+        "[ask_user(questions=[{'question': 'How many?', 'choices': ['2-4', '5+']}])]",
+      );
+      expect(result.toolCalls[0].args).toEqual({
+        questions: [{ question: "How many?", choices: ["2-4", "5+"] }],
+      });
+    });
+
+    it("should parse Python scalar literals", () => {
+      const result = parseJsonFunctionCalls(
+        "[f(n=5, ratio=1.5, ok=True, off=False, x=None, s='hi')]",
+      );
+      expect(result.toolCalls[0].args).toEqual({
+        n: 5,
+        ratio: 1.5,
+        ok: true,
+        off: false,
+        x: null,
+        s: "hi",
+      });
+    });
+
+    it("should not truncate Python-style arguments containing parentheses", () => {
+      const result = parseJsonFunctionCalls(
+        `[ask_user(q="What's your budget (roughly)?")]`,
+      );
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].args).toEqual({
+        q: "What's your budget (roughly)?",
+      });
+      expect(result.textContent).toBe("");
+    });
+
+    it("should handle unescaped apostrophes in single-quoted values", () => {
+      const result = parseJsonFunctionCalls(
+        "[ask_user(q='What's the budget?', r='Who's coming?')]",
+      );
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].args).toEqual({
+        q: "What's the budget?",
+        r: "Who's coming?",
+      });
+      expect(result.textContent).toBe("");
+    });
+
+    it("should handle unescaped apostrophes inside nested values", () => {
+      const result = parseJsonFunctionCalls(
+        "[ask_user(questions=[{'question': 'What's it cost?', 'choices': ['a', 'b']}])]",
+      );
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].args).toEqual({
+        questions: [{ question: "What's it cost?", choices: ["a", "b"] }],
+      });
+    });
+
+    it("should handle an apostrophe alongside parentheses", () => {
+      const result = parseJsonFunctionCalls(
+        "[ask_user(q='What's your budget (roughly)?')]",
+      );
+      expect(result.toolCalls[0].args).toEqual({
+        q: "What's your budget (roughly)?",
+      });
+    });
+
+    it("should handle escaped quotes in Python-style arguments", () => {
+      const result = parseJsonFunctionCalls(
+        '[ask_user(q=\'What\\\'s next?\', r="say \\"hi\\"")]',
+      );
+      expect(result.toolCalls[0].args).toEqual({
+        q: "What's next?",
+        r: 'say "hi"',
+      });
+    });
+
     it("should parse multiple Python-style calls in one bracket", () => {
       const result = parseJsonFunctionCalls('[a(x="1"), b(y="2")]');
       expect(result.toolCalls.map((c) => c.toolName)).toEqual(["a", "b"]);


### PR DESCRIPTION
Python-style tool call arguments were stored as raw text, so a call like:

```ts
[ask_user(questions=[{'question': 'How many?', 'choices': ['2-4', '5+']}])]
```

produced `{ questions: "[{'question': 'How many?', …}]" }` - a string containing
Python syntax where the schema expects an array. Any tool with an array or
object argument would fail validation.