### PR TITLE
fix(tool-calling): parse structured values in Python-style tool calls (v2)

### DIFF
--- a/.changeset/python-arg-values.md
+++ b/.changeset/python-arg-values.md
@@ -1,0 +1,15 @@
+---
+"@browser-ai/transformers-js": patch
+"@browser-ai/web-llm": patch
+"@browser-ai/core": patch
+---
+
+Parse structured argument values in Python-style tool calls.
+
+Argument values were stored as raw text, so a call like
+`[ask_user(questions=[{'question': 'How many?'}])]` produced a string
+containing Python syntax instead of an array. Values are now parsed as JSON or
+Python literals, covering lists, dicts, numbers, and `True`/`False`/`None`.
+
+Calls whose arguments contain parentheses (`q="budget (roughly)?"`) are also no
+longer truncated at the first `)`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20288,7 +20288,7 @@
     },
     "packages/vercel/core": {
       "name": "@browser-ai/core",
-      "version": "2.1.12",
+      "version": "2.1.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@mediapipe/tasks-text": "^0.10.22-rc.20250304"
@@ -20970,7 +20970,7 @@
     },
     "packages/vercel/transformers-js": {
       "name": "@browser-ai/transformers-js",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@browser-ai/shared": "*",
@@ -21384,7 +21384,7 @@
     },
     "packages/vercel/web-llm": {
       "name": "@browser-ai/web-llm",
-      "version": "2.1.7",
+      "version": "2.1.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@browser-ai/shared": "*",

--- a/packages/vercel/shared/src/tool-calling/parse-json-function-calls.ts
+++ b/packages/vercel/shared/src/tool-calling/parse-json-function-calls.ts
@@ -58,6 +58,34 @@ function parseCallColonParams(params: string): Record<string, unknown> {
 }
 
 /**
+ * Decides whether the quote at `index` actually terminates the string.
+ *
+ * Models rarely escape apostrophes, so `'What's the budget?'` is common. A
+ * single quote therefore only closes when the next meaningful character is
+ * structural; otherwise it is a literal apostrophe. Double quotes are
+ * unambiguous and always close.
+ */
+function closesQuote(text: string, index: number, quote: string): boolean {
+  if (quote !== "'") return true;
+
+  for (let i = index + 1; i < text.length; i++) {
+    const char = text[i];
+    if (char === " " || char === "\t" || char === "\n" || char === "\r") {
+      continue;
+    }
+    return (
+      char === "," ||
+      char === ":" ||
+      char === "}" ||
+      char === "]" ||
+      char === ")"
+    );
+  }
+
+  return true; // end of input
+}
+
+/**
  * Splits an argument list on commas that are not inside quotes or brackets,
  * so values like `query="Doe, Jane"` survive intact.
  */
@@ -75,7 +103,7 @@ function splitArguments(args: string): string[] {
         current += char + args[++i];
         continue;
       }
-      if (char === quote) quote = null;
+      if (char === quote && closesQuote(args, i, quote)) quote = null;
       current += char;
       continue;
     }
@@ -102,42 +130,184 @@ function splitArguments(args: string): string[] {
 }
 
 /**
+ * Rewrites a Python literal into JSON: single-quoted strings become
+ * double-quoted, and `True`/`False`/`None` become their JSON equivalents.
+ * Tokenizes rather than string-replacing so quotes and keywords appearing
+ * inside string values are left alone.
+ */
+function pythonLiteralToJson(input: string): string {
+  let out = "";
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (char === "'" || char === '"') {
+      const quote = char;
+      let value = "";
+      i++;
+
+      for (
+        ;
+        i < input.length &&
+        !(input[i] === quote && closesQuote(input, i, quote));
+        i++
+      ) {
+        if (input[i] === "\\" && i + 1 < input.length) {
+          // Unescape into the raw value; JSON.stringify re-escapes below
+          const next = input[++i];
+          value +=
+            next === "n"
+              ? "\n"
+              : next === "t"
+                ? "\t"
+                : next === "r"
+                  ? "\r"
+                  : next;
+          continue;
+        }
+        value += input[i];
+      }
+
+      out += JSON.stringify(value);
+      continue;
+    }
+
+    if (/[A-Za-z]/.test(char)) {
+      let word = "";
+      while (i < input.length && /[A-Za-z]/.test(input[i])) word += input[i++];
+      i--;
+
+      out +=
+        word === "True"
+          ? "true"
+          : word === "False"
+            ? "false"
+            : word === "None"
+              ? "null"
+              : word;
+      continue;
+    }
+
+    out += char;
+  }
+
+  return out;
+}
+
+/**
+ * Parses a single Python-style argument value into its JavaScript equivalent.
+ * Handles JSON, Python literals (lists, dicts, `True`/`None`), numbers, and
+ * quoted strings; anything unrecognized is returned as a trimmed string.
+ */
+function parsePythonValue(raw: string): unknown {
+  const value = raw.trim();
+  if (!value) return "";
+
+  const isQuoted =
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"));
+
+  // Structured or scalar literals — try JSON first, then Python syntax
+  if (!isQuoted) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      // not JSON, fall through
+    }
+
+    try {
+      return JSON.parse(pythonLiteralToJson(value));
+    } catch {
+      return value;
+    }
+  }
+
+  // Quoted string: reuse the same tokenizer so escapes are handled
+  try {
+    return JSON.parse(pythonLiteralToJson(value));
+  } catch {
+    return value.substring(1, value.length - 1);
+  }
+}
+
+/**
+ * Finds `name(...)` calls in text, tracking quotes and nesting so arguments
+ * containing parentheses (e.g. `q="budget (roughly)?"`) are not truncated.
+ */
+function scanPythonCalls(text: string): Array<{ name: string; args: string }> {
+  const calls: Array<{ name: string; args: string }> = [];
+  const nameRegex = /(\w+)\s*\(/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = nameRegex.exec(text)) !== null) {
+    const start = match.index + match[0].length;
+    let depth = 1;
+    let quote: string | null = null;
+    let i = start;
+
+    for (; i < text.length && depth > 0; i++) {
+      const char = text[i];
+
+      if (quote) {
+        if (char === "\\") i++;
+        else if (char === quote && closesQuote(text, i, quote)) quote = null;
+        continue;
+      }
+
+      if (char === '"' || char === "'") quote = char;
+      else if (char === "(") depth++;
+      else if (char === ")") depth--;
+    }
+
+    // Unbalanced — no closing paren, so this is not a complete call
+    if (depth !== 0) continue;
+
+    calls.push({ name: match[1], args: text.slice(start, i - 1) });
+    nameRegex.lastIndex = i;
+  }
+
+  return calls;
+}
+
+/**
  * Parses Python-style calls such as `func(arg="value")`. Accepts several calls
  * separated by commas, with or without the surrounding brackets.
  */
 function parsePythonStyleCalls(text: string): ParsedToolCall[] {
   const calls: ParsedToolCall[] = [];
-  const callRegex = /(\w+)\(([^)]*)\)/g;
 
-  for (const match of text.matchAll(callRegex)) {
-    const [, funcName, rawArgs] = match;
+  for (const { name, args: rawArgs } of scanPythonCalls(text)) {
     const args: Record<string, unknown> = {};
 
-    for (const pair of splitArguments(rawArgs ?? "")) {
+    for (const pair of splitArguments(rawArgs)) {
       const equalIndex = pair.indexOf("=");
       if (equalIndex <= 0) continue;
 
       const key = pair.substring(0, equalIndex).trim();
-      let value = pair.substring(equalIndex + 1).trim();
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.substring(1, value.length - 1);
-      }
-      args[key] = value;
+      args[key] = parsePythonValue(pair.substring(equalIndex + 1));
     }
 
     calls.push({
       type: "tool-call",
       toolCallId: generateToolCallId(),
-      toolName: funcName,
+      toolName: name,
       args,
     });
   }
 
   return calls;
 }
+
+/**
+ * A quoted string, either single or double, with escapes. An unescaped `'` is
+ * treated as content unless followed by a structural character, mirroring
+ * `closesQuote` so detection agrees with tokenization.
+ */
+const QUOTED = `"(?:[^"\\\\]|\\\\.)*"|'(?:[^'\\\\]|\\\\.|'(?!\\s*(?:[,:}\\])]|$)))*'`;
+/** Argument list body: bare chars, quoted strings, or one level of nesting */
+const CALL_ARGS = `(?:[^()"']|${QUOTED}|\\((?:[^()"']|${QUOTED})*\\))*`;
+/** A single Python-style call: `name(args)` */
+const PY_CALL = `\\w+\\(${CALL_ARGS}\\)`;
 
 function buildRegex(options: ParseJsonFunctionCallsOptions): RegExp {
   const patterns: string[] = [];
@@ -151,7 +321,7 @@ function buildRegex(options: ParseJsonFunctionCallsOptions): RegExp {
 
   if (options.supportPythonStyle) {
     // One or more `func(args)` calls inside brackets: [f(a="b"), g(c="d")]
-    patterns.push("\\[\\s*\\w+\\([^)]*\\)(?:\\s*,\\s*\\w+\\([^)]*\\))*\\s*\\]");
+    patterns.push(`\\[\\s*${PY_CALL}(?:\\s*,\\s*${PY_CALL})*\\s*\\]`);
   }
 
   if (options.supportCallColonStyle) {

--- a/packages/vercel/shared/test/index.test.ts
+++ b/packages/vercel/shared/test/index.test.ts
@@ -132,6 +132,81 @@ describe("@browser-ai/shared exports", () => {
       });
     });
 
+    it("should parse Python-style list and dict argument values", () => {
+      const result = parseJsonFunctionCalls(
+        "[ask_user(questions=[{'question': 'How many?', 'choices': ['2-4', '5+']}])]",
+      );
+      expect(result.toolCalls[0].args).toEqual({
+        questions: [{ question: "How many?", choices: ["2-4", "5+"] }],
+      });
+    });
+
+    it("should parse Python scalar literals", () => {
+      const result = parseJsonFunctionCalls(
+        "[f(n=5, ratio=1.5, ok=True, off=False, x=None, s='hi')]",
+      );
+      expect(result.toolCalls[0].args).toEqual({
+        n: 5,
+        ratio: 1.5,
+        ok: true,
+        off: false,
+        x: null,
+        s: "hi",
+      });
+    });
+
+    it("should not truncate Python-style arguments containing parentheses", () => {
+      const result = parseJsonFunctionCalls(
+        `[ask_user(q="What's your budget (roughly)?")]`,
+      );
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].args).toEqual({
+        q: "What's your budget (roughly)?",
+      });
+      expect(result.textContent).toBe("");
+    });
+
+    it("should handle unescaped apostrophes in single-quoted values", () => {
+      const result = parseJsonFunctionCalls(
+        "[ask_user(q='What's the budget?', r='Who's coming?')]",
+      );
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].args).toEqual({
+        q: "What's the budget?",
+        r: "Who's coming?",
+      });
+      expect(result.textContent).toBe("");
+    });
+
+    it("should handle unescaped apostrophes inside nested values", () => {
+      const result = parseJsonFunctionCalls(
+        "[ask_user(questions=[{'question': 'What's it cost?', 'choices': ['a', 'b']}])]",
+      );
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].args).toEqual({
+        questions: [{ question: "What's it cost?", choices: ["a", "b"] }],
+      });
+    });
+
+    it("should handle an apostrophe alongside parentheses", () => {
+      const result = parseJsonFunctionCalls(
+        "[ask_user(q='What's your budget (roughly)?')]",
+      );
+      expect(result.toolCalls[0].args).toEqual({
+        q: "What's your budget (roughly)?",
+      });
+    });
+
+    it("should handle escaped quotes in Python-style arguments", () => {
+      const result = parseJsonFunctionCalls(
+        '[ask_user(q=\'What\\\'s next?\', r="say \\"hi\\"")]',
+      );
+      expect(result.toolCalls[0].args).toEqual({
+        q: "What's next?",
+        r: 'say "hi"',
+      });
+    });
+
     it("should parse multiple Python-style calls in one bracket", () => {
       const result = parseJsonFunctionCalls('[a(x="1"), b(y="2")]');
       expect(result.toolCalls.map((c) => c.toolName)).toEqual(["a", "b"]);


### PR DESCRIPTION
Python-style tool call arguments were stored as raw text, so a call like:

```ts
[ask_user(questions=[{'question': 'How many?', 'choices': ['2-4', '5+']}])]
```

produced `{ questions: "[{'question': 'How many?', …}]" }` - a string containing
Python syntax where the schema expects an array. Any tool with an array or
object argument would fail validation.